### PR TITLE
Implement some test suites for unimplemented instructions

### DIFF
--- a/test/instructions/branchnil_test.rb
+++ b/test/instructions/branchnil_test.rb
@@ -4,8 +4,85 @@ require "helper"
 
 class TenderJIT
   class BranchnilTest < JITTest
-    def test_branchnil
+    # Simplified version of [Ruby 3.0.2's `branchnil` unit test](https://github.com/ruby/ruby/blob/0db68f023372b634603c74fca94588b457be084c/test/ruby/test_jit.rb#L479).
+    #
+    # Disassembly of the inner code (as of v3.0.2):
+    #
+    #     == disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(1,14)> (catch: FALSE)
+    #     local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
+    #     [ 1] a@0
+    #     0000 putobject                              2                         (   1)[Li]
+    #     0002 setlocal_WC_0                          a@0
+    #     0004 getlocal_WC_0                          a@0
+    #     0006 dup
+    #     0007 branchnil                              12
+    #     0009 putobject_INT2FIX_1_
+    #     0010 opt_plus                               <calldata!mid:+, argc:1, ARGS_SIMPLE>
+    #     0012 leave
+    #
+    def branch_not_taken
+      a = 2
+      a&.+(1)
+    end
+
+    # Modified version of `branch_not_taken`, with branching taking place.
+    #
+    # The code doesn't make much sense in itself, however, `while` is what the
+    # current Ruby UT uses, so it makes sense to use it as reference.
+    #
+    # Disassembly of the inner code (as of v3.0.2):
+    #
+    #     == disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(1,16)> (catch: FALSE)
+    #     local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
+    #     [ 1] a@0
+    #     0000 putnil                                                           (   1)[Li]
+    #     0001 setlocal_WC_0                          a@0
+    #     0003 getlocal_WC_0                          a@0
+    #     0005 dup
+    #     0006 branchnil                              11
+    #     0008 putobject_INT2FIX_1_
+    #     0009 opt_plus                               <calldata!mid:+, argc:1, ARGS_SIMPLE>
+    #     0011 leave
+    #
+    def branch_taken
+      a = nil
+      a&.+(1)
+    end
+
+    def test_branch_not_taken
       skip "Please implement branchnil!"
+
+      jit.compile method(:branch_not_taken)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+      assert_equal 0, jit.exits
+
+      jit.enable!
+      v = branch_not_taken
+      jit.disable!
+      assert_equal 3, v
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
+    def test_branch_taken
+      skip "Please implement branchnil!"
+
+      jit.compile method(:branch_taken)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+      assert_equal 0, jit.exits
+
+      jit.enable!
+      v = branch_taken
+      jit.disable!
+      assert_nil v
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
     end
   end
 end

--- a/test/instructions/intern_test.rb
+++ b/test/instructions/intern_test.rb
@@ -4,8 +4,67 @@ require "helper"
 
 class TenderJIT
   class InternTest < JITTest
-    def test_intern
+    # Disassembly of the inner code (as of v3.0.2):
+    #
+    #     == disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(1,11)> (catch: FALSE)
+    #     0000 putstring                              "c64"                     (   1)[Li]
+    #     0002 intern
+    #     0003 leave
+    #
+    def new_symbol
+      :"#{'c64'}"
+    end
+
+    # Disassembly of the inner code (as of v3.0.2):
+    #
+    #     == disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(1,48)> (catch: FALSE)
+    #     0000 putstring                              "c64"                     (   1)[Li]
+    #     0002 intern
+    #     0003 opt_send_without_block                 <calldata!mid:object_id, argc:0, ARGS_SIMPLE>
+    #     0005 putstring                              "c64"
+    #     0007 intern
+    #     0008 opt_send_without_block                 <calldata!mid:object_id, argc:0, ARGS_SIMPLE>
+    #     0010 newarray                               2
+    #     0012 leave
+    #
+    def existing_symbol
+      [:"#{'c64'}".object_id, :"#{'c64'}".object_id]
+    end
+
+    def test_new_symbol
       skip "Please implement intern!"
+
+      jit.compile method(:new_symbol)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+      assert_equal 0, jit.exits
+
+      jit.enable!
+      v = new_symbol
+      jit.disable!
+      assert_equal :c64, v
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
+    def test_existing_symbol
+      skip "Please implement intern!"
+
+      jit.compile method(:existing_symbol)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+      assert_equal 0, jit.exits
+
+      jit.enable!
+      id1, id2 = existing_symbol
+      jit.disable!
+      assert_equal id1, id2
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
     end
   end
 end

--- a/test/instructions/opt_aset_test.rb
+++ b/test/instructions/opt_aset_test.rb
@@ -4,8 +4,79 @@ require "helper"
 
 class TenderJIT
   class OptAsetTest < JITTest
-    def test_opt_aset
-      skip "Please implement opt_aset!"
+    # Disassembly of the inner code (as of v3.0.2):
+    #
+    #     0000 putnil                                                           (   1)[Li]
+    #     0001 newhash                                0
+    #     0003 putobject                              :key
+    #     0005 putstring                              "val"
+    #     0007 setn                                   3
+    #     0009 opt_aset                               <calldata!mid:[]=, argc:2, ARGS_SIMPLE>
+    #     0011 pop
+    #     0012 leave
+    #
+    def opt_aset_hash
+      {}[:key] = 'val'
+    end
+
+    # Disassembly of the inner code (as of v3.0.2):
+    #
+    #     == disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(1,15)> (catch: FALSE)
+    #     0000 putnil                                                           (   1)[Li]
+    #     0001 duparray                               [0]
+    #     0003 putobject_INT2FIX_1_
+    #     0004 putstring                              "val"
+    #     0006 setn                                   3
+    #     0008 opt_aset                               <calldata!mid:[]=, argc:2, ARGS_SIMPLE>
+    #     0010 pop
+    #     0011 leave
+    #
+    # As of 27/Sep/2021, `newarray` (which creates an empty array) is not implemented,
+    # so we need to create a filled array (which uses `duparray`).
+    #
+    def opt_aset_array
+      [0][1] = 'val'
+    end
+
+    def test_opt_aset_hash
+      # This also requires any hash creation instruction to be implemented.
+      #
+      skip "Please implement opt_aset for hashes!"
+
+      jit.compile method(:opt_aset_hash)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+      assert_equal 0, jit.exits
+
+      jit.enable!
+      v = opt_aset_hash
+      jit.disable!
+      assert_equal 'val', v
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
+    # Only (absence of) side-effects can be tested, but it's not typical in this
+    # project, so only exit/error-free execution is tested.
+    #
+    def test_opt_aset_array
+      skip "Please implement opt_aset for arrays!"
+
+      jit.compile method(:opt_aset_array)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+      assert_equal 0, jit.exits
+
+      jit.enable!
+      v = opt_aset_array
+      jit.disable!
+      assert_equal 'val', v
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
     end
   end
 end


### PR DESCRIPTION
A few suites that, for one reason or another (not noticing that a given instruction, or that parts of the workflow required for its testing, are not supported) are not currently supported.

I think that having the test suites ready will spare sometimes before/during/after the corresponding instructions will be implemented :^)

An alternative approach, potentially preferrable, to keep test suites for unimplemented instructions, is to allow `exit`s. One exception to this is `opt_aset` for arrays, which has a hardcoded runtime exception.