### PR TITLE
Fix warnings displayed during test run

### DIFF
--- a/test/ruby_internals_test.rb
+++ b/test/ruby_internals_test.rb
@@ -124,7 +124,7 @@ class TenderJIT
       assert_equal [-Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP], rObject_as_heap.types
 
       # Check the "ary" member. It's an array of unsigned long
-      assert_equal -Fiddle::TYPE_LONG, rObject_as.types.last.type
+      assert_equal (-Fiddle::TYPE_LONG), rObject_as.types.last.type
       assert_equal 3, rObject_as.types.last.len
     end
 
@@ -217,7 +217,6 @@ class TenderJIT
       fisk = Fisk.new
 
       jitbuf = Fisk::Helpers.jitbuffer 4096
-      fmt = "%x\n"
 
       tc = self
       fisk.asm(jitbuf) do
@@ -312,7 +311,6 @@ class TenderJIT
 
       fisk = Fisk.new
 
-      rb = self.rb
       binary = fisk.asm do
         push rbp
         mov rcx, rdi # save the first parameter, it's the iseq


### PR DESCRIPTION
There are (were) three warnings raised during the test run, caused by code in `test/ruby_internals_test.rb`:

```
- 127: warning: ambiguous first argument; put parentheses or a space even after `-' operator`
  - assert_equal -Fiddle::TYPE_LONG, rObject_as.types.last.type
- 220: warning: assigned but unused variable - fmt`
- 315: warning: assigned but unused variable - rb`
```

This PR fixes them all.