### PR TITLE
flush PC and SP before calling Ruby function

### DIFF
--- a/test/instructions/opt_aref_test.rb
+++ b/test/instructions/opt_aref_test.rb
@@ -83,5 +83,22 @@ class TenderJIT
       assert_equal 4, jit.executed_methods
       assert_equal 0, jit.exits
     end
+
+    def test_opt_aref_does_not_crash
+      @peeks = {}
+      jit.compile method(:add_mappings)
+      jit.enable!
+      add_mappings(Object.new)
+      add_mappings(Object.new)
+      add_mappings(Object.new)
+      jit.enable!
+    end
+
+    private
+
+    def add_mappings(peek)
+      # filter the logically equivalent objects
+      @peeks[peek] ||= peek
+    end
   end
 end


### PR DESCRIPTION
Anything that can possibly push a Ruby frame could mess up the caller's
frame.  We need to flush our PC and SP so that if there is an exception
we can get the right trace (from the PC) and so that the calling frame
doesn't clobber our stack (the SP)