### PR TITLE
Fix compiling methods loaded from binary iseqs

### DIFF
--- a/lib/tenderjit.rb
+++ b/lib/tenderjit.rb
@@ -481,7 +481,7 @@ class TenderJIT
     ptr = body.variable.coverage.to_i
 
     ary = nil
-    if ptr == 0
+    if ptr == 0 || ptr == Qnil
       ary = []
       body.variable.coverage = Fiddle.dlwrap(ary)
     else

--- a/test/tenderjit_test.rb
+++ b/test/tenderjit_test.rb
@@ -165,6 +165,18 @@ class TenderJIT
     end
   end
 
+  class SpecialMethods < JITTest
+    class Foo
+    end
+
+    def test_special_methods_do_not_break
+      jit.compile Foo.instance_method(:tap)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+  end
+
   class CompileItself < JITTest
     def fib n
       if n < 3


### PR DESCRIPTION
When iseqs get loaded from binary, the coverage pointer is set to Qnil
rather than Qfalse.  Both of those cases need to set an array inside the
iseq struct.