### PR TITLE
[Refactoring] Move `push` && `pop` REG_BP alignment to the `Runtime#call_cfunc` method

### DIFF
--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -364,6 +364,12 @@ class TenderJIT
     end
 
     def call_cfunc func_loc, params
+      @fisk.push REG_BP.to_register # alignment
+      call_cfunc_without_alignment func_loc, params
+      @fisk.pop REG_BP.to_register  # alignment
+    end
+
+    def call_cfunc_without_alignment func_loc, params
       raise NotImplementedError, "too many parameters" if params.length > 6
       raise "No function location" unless func_loc > 0
 


### PR DESCRIPTION
Shamelessly implementing the refactoring suggested by @tenderlove on the hexdev talk

The solution is pretty straightforward - Instead of wrapping every `call_cfunc` method call with `push` & `pop` alignments pop we are moving it into the `call_cfunc` method itself.

The only concerning place is the `handle_newarray` which has more additional code in between `push` & `pop` alignments apart from the `call_cfunc` call itself, but something suggests me that it should be fine. However I'm yet not familiar with the code enough to evaluate this concern. Would love to hear an opinion!
https://github.com/tenderlove/tenderjit/blob/d8ecbb87452a8406fcd7bb45c3f4f9cb2dddfa21/lib/tenderjit/iseq_compiler.rb#L1134-L1140
I've also considered defining a new "wrapper function" like:
```ruby
def call_cfunc_with_alignment func_loc, params
  push_reg REG_BP
  call_cfunc func_loc, params
  pop_reg REG_BP
end
```
to leave the option to call the `call_cfunc` without an alignment and use it in cases like `handle_newarray`, but might be an overkill 😕 


I think I should be able to do the same with the `rb_funcall` calls. Just wanted to gather opinions on `call_cfunc` refactoring before refactoring `rb_funcall`
https://github.com/tenderlove/tenderjit/blob/05fd753fa6177ea4e4c9525a6330c07cb064e4e4/lib/tenderjit/iseq_compiler.rb#L464-L466