### PR TITLE
Fix `newarray` case when the array is empty

### DIFF
--- a/test/instructions/newarray_test.rb
+++ b/test/instructions/newarray_test.rb
@@ -6,14 +6,29 @@ class TenderJIT
   class NewarrayTest < JITTest
     def bar; 1; end
 
-    def foo
+    def empty_array
+      []
+    end
+
+    def filled_array
       [bar, bar, bar]
     end
 
-    def test_newarray
-      jit.compile(method(:foo))
+    def test_empty_array
+      jit.compile(method(:empty_array))
       jit.enable!
-      v = foo
+      v = empty_array
+      jit.disable!
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.exits
+      assert_equal [], v
+    end
+
+    def test_newarray_filled
+      jit.compile(method(:filled_array))
+      jit.enable!
+      v = filled_array
       jit.disable!
 
       assert_equal 2, jit.compiled_methods


### PR DESCRIPTION
When there are not values to create an array from, there is no meaningful address
to pass; Ruby doesn't use the address in this case (see https://github.com/ruby/ruby/blob/v3_0_2/array.c#L838).
For simplicity/safety, we send a null pointer.