### PR TITLE
[Refactoring] Move REG_BP alignment to the Runtime#rb_funcall method

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -382,7 +382,7 @@ class TenderJIT
           rt.push_reg REG_BP
           rt.push_reg REG_BP
           rt.push_reg rt.c_param(0)
-          rt.rb_funcall self, :compile_setinstancevariable, [cfp_ptr.self, req, rt.return_value]
+          rt.rb_funcall_without_alignment self, :compile_setinstancevariable, [cfp_ptr.self, req, rt.return_value]
           rt.pop_reg rt.c_param(0)
           rt.pop_reg REG_BP
           rt.pop_reg REG_BP
@@ -461,9 +461,7 @@ class TenderJIT
             rt.pointer(rt.return_value)[0] = temp
             temp.release!
 
-            rt.push_reg REG_BP
             rt.rb_funcall self, :compile_getinstancevariable, [cfp_ptr.self, req, rt.return_value]
-            rt.pop_reg REG_BP
 
             rt.NUM2INT(rt.return_value)
 
@@ -617,9 +615,7 @@ class TenderJIT
         ctx.with_runtime do |rt|
           cfp_ptr = rt.pointer(REG_CFP, type: RbControlFrameStruct)
 
-          rt.push_reg REG_BP # alignment
           rt.rb_funcall self, :compile_opt_aref, [cfp_ptr.sp, req, ctx.fisk.rax]
-          rt.pop_reg REG_BP # alignment
 
           rt.NUM2INT(rt.return_value)
 
@@ -682,9 +678,7 @@ class TenderJIT
             rt.pointer(rt.return_value)[0] = temp
             temp.release!
 
-            rt.push_reg REG_BP
             rt.rb_funcall self, :compile_opt_send_without_block, [cfp_ptr.sp, compile_request, ctx.fisk.rax]
-            rt.pop_reg REG_BP
 
             rt.NUM2INT(rt.return_value)
 
@@ -1187,9 +1181,7 @@ class TenderJIT
         ctx.with_runtime do |rt|
           cfp_ptr = rt.pointer(REG_CFP, type: RbControlFrameStruct)
 
-          rt.push_reg REG_BP
           rt.rb_funcall self, :compile_jump, [cfp_ptr.sp, patch_request, rt.return_value]
-          rt.pop_reg REG_BP
 
           rt.NUM2INT(rt.return_value)
 
@@ -1250,9 +1242,7 @@ class TenderJIT
           ctx.with_runtime do |rt|
             cfp_ptr = rt.pointer(REG_CFP, type: RbControlFrameStruct)
 
-            rt.push_reg REG_BP
             rt.rb_funcall self, :compile_jump, [cfp_ptr.sp, patch, ctx.fisk.rax]
-            rt.pop_reg REG_BP
 
             rt.NUM2INT(rt.return_value)
 
@@ -1334,9 +1324,7 @@ class TenderJIT
         ctx.with_runtime do |rt|
           cfp_ptr = rt.pointer(REG_CFP, type: RbControlFrameStruct)
 
-          rt.push_reg REG_BP
           rt.rb_funcall self, :compile_opt_getinlinecache, [cfp_ptr.sp, patch_request, ctx.fisk.rax]
-          rt.pop_reg REG_BP
 
           rt.NUM2INT(rt.return_value)
 
@@ -1405,9 +1393,7 @@ class TenderJIT
         ctx.with_runtime do |rt|
           cfp_ptr = rt.pointer(REG_CFP, type: RbControlFrameStruct)
 
-          rt.push_reg REG_BP
           rt.rb_funcall self, :compile_jump, [cfp_ptr.sp, patch_request, ctx.fisk.rax]
-          rt.pop_reg REG_BP
 
           rt.NUM2INT(rt.return_value)
 
@@ -1740,9 +1726,7 @@ class TenderJIT
         ctx.with_runtime do |rt|
           cfp_ptr = rt.pointer(REG_CFP, type: RbControlFrameStruct)
 
-          rt.push_reg REG_BP # alignment
           rt.rb_funcall self, :compile_opt_aset, [cfp_ptr.sp, req, rt.return_value]
-          rt.pop_reg REG_BP # alignment
 
           rt.NUM2INT(rt.return_value)
 

--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -69,6 +69,12 @@ class TenderJIT
     end
 
     def rb_funcall recv, method_name, params
+      @fisk.push REG_BP.to_register # alignment
+      rb_funcall_without_alignment recv, method_name, params
+      @fisk.pop REG_BP.to_register  # alignment
+    end
+
+    def rb_funcall_without_alignment recv, method_name, params
       raise "Too many parameters!" if params.length > 3
 
       func_addr = Internals.symbol_address "rb_funcall"


### PR DESCRIPTION
Similar to https://github.com/tenderlove/tenderjit/pull/16

Since almost every call to `rb_funcall` needs to be "wrapped" in the `push` and `pop` alignments it seems reasonable to move it in the method itself
However, just to play safe, I've also defined `rb_funcall_without_alignment` for some concerning cases like:
https://github.com/tenderlove/tenderjit/blob/324ef15e6d00786530c197e31a85c6e4b04d13af/lib/tenderjit/iseq_compiler.rb#L382-L388