### PR TITLE
Implement tostring

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -266,6 +266,14 @@ class TenderJIT
       code_start
     end
 
+    def handle_putstring str
+      addr = Fiddle::Handle::DEFAULT["rb_ec_str_resurrect"]
+      with_runtime do |rt|
+        rt.call_cfunc addr, [REG_EC, str]
+        rt.push rt.return_value, name: :string
+      end
+    end
+
     def handle_getglobal gid
       addr = Fiddle::Handle::DEFAULT["rb_gvar_get"]
       with_runtime do |rt|

--- a/test/instructions/putstring_test.rb
+++ b/test/instructions/putstring_test.rb
@@ -1,11 +1,27 @@
-# frozen_string_literal: true
-
 require "helper"
 
 class TenderJIT
   class PutstringTest < JITTest
+
+    # == disasm: #<ISeq:foo@x.rb:1 (1,0)-(3,3)> (catch: FALSE)
+    # 0000 putstring                              "hello, world"            (   2)[LiCa]
+    # 0002 leave                                                            (   3)[Re]
+    def foo
+      "hello, world"
+    end
+
     def test_putstring
-      skip "Please implement putstring!"
+      m = method(:foo)
+      assert_has_insn m, insn: :putstring
+
+      jit.compile(method(:foo))
+      jit.enable!
+      v = foo
+      jit.disable!
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.exits
+      assert_equal "hello, world", v
     end
   end
 end


### PR DESCRIPTION
Implement `tostring` operation

YARV definition:
https://github.com/ruby/ruby/blob/1f5f8a187adb746b01cc95c3f29a0a355f513374/insns.def#L362-L369

As far as I understand the instruction is pretty simple:
1. pop value from stack
2. call `rb_ec_str_resurrect` with execution context and the value
3. push returned value on to the stack 

Even though the instruction seem straightforward, I'm not sure I'm using correct tenderjit objects to implement it. So please feel free to raise any concerns!

### Tests

I had to remove the `# frozen_string_literal: true` instruction from the test file, otherwise the instruction turns into `putobject` instead of `putstring`
Is there any better way to generate some code with `putstring` instruction but without getting rid of the frozen string literal statement?
Thanks!
