### PR TITLE
Remove crabstone dev dep

### DIFF
--- a/tenderjit.gemspec
+++ b/tenderjit.gemspec
@@ -17,5 +17,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("elftools", "~> 1.0")
   s.add_development_dependency("rake", "~> 13.0")
   s.add_development_dependency("minitest", "~> 5.14")
-  s.add_development_dependency("crabstone", "~> 4.0")
 end

--- a/test/ruby_internals_test.rb
+++ b/test/ruby_internals_test.rb
@@ -156,14 +156,6 @@ class TenderJIT
     end
 
     require "fisk"
-    require "crabstone"
-
-    def print_disasm binary
-      cs = Crabstone::Disassembler.new(Crabstone::ARCH_X86, Crabstone::MODE_64)
-      cs.disasm(binary, 0x0000).each {|i|
-        printf("0x%x:\t%s\t\t%s\n",i.address, i.mnemonic, i.op_str)
-      }
-    end
 
     def test_constant_body_size
       rb_iseq_constant_body = rb.struct("rb_iseq_constant_body")


### PR DESCRIPTION
It's handy for debugging but not really required for development right
now.