### PR TITLE
Runtime#if_eq: Improve handling of the CMP instruction (immediate) operators

### DIFF
--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -265,6 +265,11 @@ class TenderJIT
       lhs = cast_to_fisk lhs
       rhs = cast_to_fisk rhs
 
+      # The swap could be avoided in the lhs:imm64 sub-case, but keep it simple for now,
+      # as it may be entirely removed in the future.
+      #
+      lhs, rhs = rhs, lhs if lhs.immediate? && !rhs.immediate?
+
       maybe_reg lhs do |op1|
         maybe_reg rhs, only_64: true do |op2|
           @fisk.cmp op1, op2

--- a/test/runtime_test.rb
+++ b/test/runtime_test.rb
@@ -27,5 +27,18 @@ class TenderJIT
     def test_if_eq_imm_immnot64
       @rt.if_eq(2 << 0, 2 << 0)
     end
+
+    # See https://github.com/tenderlove/tenderjit/issues/35#issuecomment-934872857
+    #
+    # > The code in main is emitting an extra mov instruction because the lhs is
+    # > an immediate when we could have put the lhs in the rhs and directly used
+    # > the CMP instruction.
+    #
+    # When tackling, update all the invocations, then turn the swap into an
+    # assertion.
+    #
+    def test_if_eq_imm_not_imm
+      skip "Optimize the if_eq invocations"
+    end
   end # class RuntimeTest
 end


### PR DESCRIPTION
Primarily, this fixes #35, where a left (imm < 64) operand would cause an error (due to CMP imm64, $op not existing).

This PR also adds a smoke Runtime test suite.