### PR TITLE
Rake test task: Add support for test suite prefix and unit test name

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,8 @@ require "rake/clean"
 
 require_relative "lib/tenderjit/ruby_interpreter_metadata_helper"
 
+TEST_SUITE_DEFAULT_PREFIX='*'
+
 test_files = RubyVM::INSTRUCTION_NAMES.grep_v(/^trace_/).map do |name|
   test_file = "test/instructions/#{name}_test.rb"
   file test_file do |t|
@@ -39,14 +41,37 @@ end
 
 task :compile => gen_files.first
 
-Rake::TestTask.new do |t|
-  t.libs << "test"
-  t.test_files = FileList['test/**/*_test.rb']
-  t.verbose = true
-  t.warning = true
-end
-
 task :default => 'lib/tendertools/dwarf/constants.rb'
-task :test => test_files + [:compile]
+
+# Run the test suites.
+#
+# Test suites are assumed to be under any subdirectory level of `test`, and with
+# a filename ending with `_test.rb`.
+#
+# Arguments:
+#
+# - :test_suite_prefix: test suite prefix, in glob format; can include slashes.
+#   defaults to TEST_SUITE_DEFAULT_PREFIX.
+#   example: `foo/bar` will match `test/**/foo/bar_test.rb`
+# - :test_bare_name: test name (without prefix); if nil, all the UTs are run.
+#   defaults to run all the UTs.
+#   example: `empty_array` will run `test_empty_array`
+#
+task :test, [:test_suite_prefix, :test_bare_name] => test_files + [:compile] do |_, args|
+  Rake::TestTask.new do |t|
+    test_suite_prefix = args.test_suite_prefix || TEST_SUITE_DEFAULT_PREFIX
+
+    t.libs << "test"
+    t.test_files = FileList["test/**/#{test_suite_prefix}_test.rb"]
+
+    # This is somewhat hacky, but TestTask doesn't leave many... options 😬
+    # See source (`rake-$version/lib/rake/testtask.rb`).
+    #
+    t.options = "-ntest_#{args.test_bare_name}" if args.test_bare_name
+
+    t.verbose = true
+    t.warning = true
+  end
+end
 
 CLEAN.include "lib/tenderjit/ruby"


### PR DESCRIPTION
Allows test suite (prefix) and unit test name to be specified in the Rake `test` task.

Example runs:

- `rake test[foo]`    : runs `test/**/foo_test.rb`
- `rake test[foo/bar]`: runs `test/**/foo/bar_test.rb`
- `rake test[foo,baz]`: runs `test/**/foo_test.rb` -> only `:test_baz`

Makes @tenderlove super happy 😆

Note that this is approach is very strongly oriented to user-convenience (at least, in my acceptation of convenience 😬), so let me know if I need to scale back, e.g. don't imply `test_` and so on.

Also, I'm assuming that the user is not attacking himself with the argument values (e.g. `; rm -rf $HOME`); I can escape the arguments if this should be prevented.

Closes #43.