### PR TITLE
Instruction handlers modernization (second batch)

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -1663,7 +1663,7 @@ class TenderJIT
             end
 
       with_runtime do |rt|
-        rt.push Fisk::Imm64.new(literal), name: object_name
+        rt.push literal, name: object_name
       end
     end
 
@@ -1678,7 +1678,7 @@ class TenderJIT
         rt.write Fisk::Registers::RAX, stack_top
 
         # Pop the frame from the stack
-        rt.add REG_CFP, Fisk::Imm32.new(RbControlFrameStruct.byte_size)
+        rt.add REG_CFP, RbControlFrameStruct.byte_size
 
         # Write the frame pointer back to the ec
         rt.write Fisk::M64.new(REG_EC, RbExecutionContextT.offsetof("cfp")), REG_CFP
@@ -1776,7 +1776,7 @@ class TenderJIT
 
         # If it returned nil, make a new array
         rt.if_eq(rt.return_value, Fisk::Imm64.new(Qnil)) {
-          rt.call_cfunc rb.symbol_address("rb_ary_new_from_args"), [Fisk::Imm64.new(1), rt.return_value]
+          rt.call_cfunc rb.symbol_address("rb_ary_new_from_args"), [1, rt.return_value]
         }.else {}
 
         rt.write store_loc, rt.return_value


### PR DESCRIPTION
Second batch of the modernization of instruction handlers, for less trivial handlers.

This requires a more attentive review, since the changes here were more radical, and may have introduced subtle issues.

A few notes:

- splatarray: this can't run yet, but it was still worth updating before it's going to be fully implemented
- putobject_literal: I'm not sure about the :name field values; I suppose that they're cosmetic, but it'd be good to know which are the semantically correct values
- leave
  - I'm not sure what's the idiomatic way of gathering an accordingly sized immediate in an idiomatic way (without accessinng the Fisk instance); I've set a 32 bit value, since 64 bits are going to break the original code anyway (due to `ADD reg, imm64` not existing)
  - for mysterious (to me) reasons, using `rt.return` crashes, even if it seems to be the very direct translation of `__.ret`