### PR TITLE
Implement `tostring` instruction (shallow)

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -1153,6 +1153,18 @@ class TenderJIT
       end
     end
 
+    def handle_tostring
+      rb_obj_as_string_result = Fiddle::Handle::DEFAULT["rb_obj_as_string_result"]
+
+      str = @temp_stack.pop
+      val = @temp_stack.pop
+
+      with_runtime do |rt|
+        rt.call_cfunc rb_obj_as_string_result, [str, val]
+        rt.push rt.return_value, name: RUBY_T_STRING
+      end
+    end
+
     class BranchUnless < Struct.new(:jump_idx, :jump_type, :temp_stack)
     end
 

--- a/test/instructions/tostring_test.rb
+++ b/test/instructions/tostring_test.rb
@@ -4,8 +4,33 @@ require "helper"
 
 class TenderJIT
   class TostringTest < JITTest
+    # Disasm (as of 3.0.2):
+    #
+    #     0000 putobject                              ""                        (   1)[Li]
+    #     0002 putobject                              :a
+    #     0004 dup
+    #     0005 opt_send_without_block                 <calldata!mid:to_s, argc:0, FCALL|ARGS_SIMPLE>
+    #     0007 tostring
+    #     0008 concatstrings                          2
+    #     0010 leave
+    #
+    def tostring
+      "#{:a}"
+    end
+
     def test_tostring
-      skip "Please implement tostring!"
+      meth = method(:tostring)
+
+      assert_has_insn meth, insn: :tostring
+
+      jit.compile(meth)
+      jit.enable!
+      v = meth.call
+      jit.disable!
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.exits
+      assert_equal "a", v
     end
   end
 end


### PR DESCRIPTION
Shallow implementation of the `tostring` instruction (the invoked function hasn't been inlined).