### PR TITLE
Use `Fiddle::Handle::DEFAULT` to find mjit symbols

### DIFF
--- a/lib/tenderjit.rb
+++ b/lib/tenderjit.rb
@@ -90,8 +90,12 @@ class TenderJIT
 
   # Global Variables
 
-  MJIT_CALL_P = Fiddle::Pointer.new(Internals.symbol_address("mjit_call_p"))
-  MJIT_OPTIONS = Internals.struct("mjit_options").new(Internals.symbol_address("mjit_opts"))
+  MJIT_CALL_P = Fiddle::Pointer.new(Fiddle::Handle::DEFAULT["mjit_call_p"])
+
+  ## FIXME: These addresses are sometimes different.  Why???
+  # p Fiddle::Handle::DEFAULT["mjit_opts"].to_s(16)
+  # p Internals.symbol_address("mjit_opts").to_s(16)
+  MJIT_OPTIONS = Internals.struct("mjit_options").new(Fiddle::Handle::DEFAULT["mjit_opts"])
 
   MJIT_OPTIONS.min_calls = 5
   MJIT_OPTIONS.wait = 0

--- a/lib/tenderjit/fiddle_hacks.rb
+++ b/lib/tenderjit/fiddle_hacks.rb
@@ -93,7 +93,7 @@ module Fiddle
         end
 
         def write base, val
-          data = [val].pack("l!")
+          data = [val].pack(unpack)
           Fiddle::Pointer.new(base)[offset, byte_size] = data
           nil
         end


### PR DESCRIPTION
It seems like Internals.symbol_address is not reliable, and I'm not sure
why.  We should use `Fiddle::Handle::DEFAULT` where we can (since it is
always correct), but also figure out why the other API is wrong.  I
assume it's something to do with ASLR, but I'm not sure.

Refs #51 