### PR TITLE
Subtract one from the index we use when calling `concatstrings`

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -551,7 +551,7 @@ class TenderJIT
     end
 
     def handle_concatstrings num
-      loc = @temp_stack[num + 1]
+      loc = @temp_stack[num - 1]
       num.times { @temp_stack.pop }
       addr = Fiddle::Handle::DEFAULT["rb_str_concat_literals"]
       with_runtime do |rt|

--- a/test/instructions/tostring_test.rb
+++ b/test/instructions/tostring_test.rb
@@ -32,5 +32,24 @@ class TenderJIT
       assert_equal 0, jit.exits
       assert_equal "a", v
     end
+
+    def complex_tostring
+      "#{1234}#{5678}"
+    end
+
+    def test_complex_tostring
+      meth = method(:complex_tostring)
+
+      assert_has_insn meth, insn: :tostring
+
+      jit.compile(meth)
+      jit.enable!
+      v = meth.call
+      jit.disable!
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.exits
+      assert_equal "12345678", v
+    end
   end
 end


### PR DESCRIPTION
Our temporary stack is a 0 based array and the index we pass in is
"inclusive".  So if we want the top 3 elements we need to pass an index
of 2.  However, the concatstrings instructions gets the number 3 to mean
"3 elements".  So we just need to subtract one from the index.

Fixes: #55

Co-Authored-By: Nikita Vasilevsky <nikita.vasilevsky@shopify.com>