### PR TITLE
Implement handle_swap

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -2234,6 +2234,18 @@ class TenderJIT
       end
     end
 
+    def handle_swap
+      with_runtime do |rt|
+        temp = rt.temp_var
+        temp.write @temp_stack[0]
+
+        rt.write @temp_stack[0], @temp_stack[1]
+        rt.write @temp_stack[1], temp
+
+        temp.release!
+      end
+    end
+
     def handle_opt_aset call_data
       cd = RbCallData.new call_data
       ci = RbCallInfo.new cd.ci

--- a/test/instructions/swap_test.rb
+++ b/test/instructions/swap_test.rb
@@ -4,8 +4,23 @@ require "helper"
 
 class TenderJIT
   class SwapTest < JITTest
+    def method_with_swap
+      defined?([[]])
+    end
+
     def test_swap
-      skip "Please implement swap!"
+      m = method(:method_with_swap)
+
+      assert_has_insn m, insn: :swap
+
+      jit.compile(m)
+      jit.enable!
+      v = m.call
+      jit.disable!
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.exits
+      assert_equal "expression", v
     end
   end
 end


### PR DESCRIPTION
Implement `swap` instruction

I'm sorry for picking up such a low hanging fruit, next time I'll try to work on a more complex one! 

The instruction is very simple, swap two top values on the stack:
https://github.com/ruby/ruby/blob/1f5f8a187adb746b01cc95c3f29a0a355f513374/insns.def#L588-L595
```
DEFINE_INSN
swap
()
(VALUE val, VALUE obj)
(VALUE obj, VALUE val)
{
    /* none */
}
```

The test is a little bit overcomplicated to make it fail if instruction is implemented but the values are not swapped


### Potential solutions

#### 1. The most straightforward (?)
**Cons**: Exposes `Item` instances from `TempStack` class, not sure if we want that. Even though they are kind of exposed trough `TempStack#peek` method
**Pros**: Seems to be the most understandable for someone even with a little context on TenderJIT

```ruby
      val1 = @temp_stack.pop_item
      val2 = @temp_stack.pop_item
      
      # could be improved to
      # val2, val1 = @temp_stack.first(2)
      # but I find it less readable and a bit more risky to get lost in ordering

      @temp_stack.push_item val1
      @temp_stack.push_item val2
```

#### 2. Similar to the above

**Pros**: Compared to the one above we are not exposing `Item` objects
**Cons**: `push_mem` might be an undesirable addition to the temp stack, not sure 🤔 

```ruby
class TempStack
    def push_mem m, name:, type: nil
      @stack.push Item.new(name, type, m)
      m
    end
end

    def handle_swap
      val1 = @temp_stack.pop
      val2 = @temp_stack.pop

      @temp_stack.push_mem val1, name: :unknown, type: :unknown
      @temp_stack.push_mem val2, name: :unknown, type: :unknown
   end
```


#### 3. Implemented
⚠️  I am a little concerned that we are not doing explicit pop and push even though we are swapping the values
```ruby
      with_runtime do |rt|
        temp = rt.temp_var
        temp.write @temp_stack.peek(0).loc

        rt.write @temp_stack.peek(0).loc, @temp_stack.peek(1).loc
        rt.write @temp_stack.peek(1).loc, temp

        temp.release!
      end
```

It passes the test but I'm not sure if that's a correct implementation. I guess it is going to keep the stack in an incorrect state? Would love to hear opinions to learn!


#### 4. The most performant (?)
Should we try to aim making `handle_` methods as fast as possible? (Especially if it hurts readability) 

```ruby
class TempStack
    def set idx, value
      idx = @stack.length - idx - 1
      raise IndexError if idx < 0
      @stack[idx] = value
    end
end

    def handle_swap
      temp = @temp_stack.peek 0
      @temp_stack.set 0, @temp_stack.peek(1)
      @temp_stack.set 1, temp
    end
```





