### PR TITLE
Rakefile: Don't generate the `reverse` test suite

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,10 @@ TEST_SUITE_DEFAULT_PREFIX='*'
 DEBUG_LIBRARIES = %w[fiddle fisk worf odinflex]
 
 test_files = RubyVM::INSTRUCTION_NAMES.grep_v(/^trace_/).each_with_object([]) do |name, files|
+  # Since this instruction has been removed in 3.1, ignore it entirely.
+  # This can be removed once/if the support for versions <= 3.0 is discontinued.
+  next if name == 'reverse'
+
   test_file = "test/instructions/#{name}_test.rb"
   file test_file do |t|
     File.open(test_file, "w") do |f|


### PR DESCRIPTION
The test suite file has been removed in 552e31ca7661a2f91143026923b127f297712891, however, if the instruction is not skipped, the file will be generated when running on Ruby <= 3.0.