### PR TITLE
Prevent passing negative value as stack index

### DIFF
--- a/lib/tenderjit/temp_stack.rb
+++ b/lib/tenderjit/temp_stack.rb
@@ -25,19 +25,15 @@ class TenderJIT
     # Returns the info stored for stack location +idx+.  0 is the TOP of the
     # stack, or the last thing pushed.
     def peek idx
-      idx = @stack.length - idx - 1
-      raise IndexError if idx < 0
-      @stack.fetch(idx)
+      stack_idx = @stack.length - idx - 1
+      raise IndexError if [idx, stack_idx].any?(&:negative?)
+      @stack.fetch(stack_idx)
     end
 
     # Returns the stack location +idx+.  0 is the TOP of the stack, or the last
     # thing that was pushed.
     def [] idx
-      idx = @stack.length - idx - 1
-      raise IndexError if idx < 0
-      @stack.fetch(idx) {
-        return Fisk::M64.new(REG_BP, idx * @sizeof_sp)
-      }.loc
+      peek(idx).loc
     end
 
     def first num = nil

--- a/test/temp_stack_test.rb
+++ b/test/temp_stack_test.rb
@@ -15,12 +15,20 @@ class TempStackTest < TenderJIT::Test
     assert_raises IndexError do
       stack[1]
     end
+
+    assert_raises IndexError do
+      stack[-1]
+    end
   end
 
   def test_negative_index_raise_index_error_with_peek
     stack = TenderJIT::TempStack.new
     assert_raises IndexError do
       stack.peek(1)
+    end
+
+    assert_raises IndexError do
+      stack.peek(-1)
     end
   end
 


### PR DESCRIPTION
`IndexError` was added recently to prevent calculating a negative index. Thanks really cool! 🥇 
But there is one weird case is missing which results in an unexpected behaviour:
 ```ruby
(rdb:1) @temp_stack[-22]
<Fisk::M64:0x00007fe2d3a35f80
@register=#<Fisk::Registers::Register:0x00007fe2c42c6240
@name="r15", @type="r64", @value=15>, @displacement=192>
```

This PR aims to prevent such cases