### PR TITLE
Address YJIT constant rename to RubyVM::YJIT

### DIFF
--- a/test/ruby_internals_test.rb
+++ b/test/ruby_internals_test.rb
@@ -166,7 +166,7 @@ class TenderJIT
 
     def test_constant_body_size
       rb_iseq_constant_body = rb.struct("rb_iseq_constant_body")
-      if Object.const_defined?(:YJIT)
+      if RubyVM.const_defined?(:YJIT)
         assert_equal 304, rb_iseq_constant_body.byte_size
       else
         assert_equal 288, rb_iseq_constant_body.byte_size
@@ -209,7 +209,7 @@ class TenderJIT
       rb_iseq_constant_body = rb.struct("rb_iseq_constant_body")
       rb_execution_context_t = rb.struct("rb_execution_context_struct")
       rb_control_frame_struct = rb.struct("rb_control_frame_struct")
-      if Object.const_defined?(:YJIT)
+      if RubyVM.const_defined?(:YJIT)
         assert_equal 64, rb_control_frame_struct.byte_size
       else
         assert_equal 56, rb_control_frame_struct.byte_size


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/e53d07f583866e6df7a88963ada33cad68018ebd
`YJIT` constant was renamed to `RubyVM::YJIT`
It causes TenderJIT ci to fail on ruby-head