### PR TITLE
Implements getblockparamproxy and also start on optimized method types

### DIFF
--- a/lib/tenderjit/ruby.rb
+++ b/lib/tenderjit/ruby.rb
@@ -177,6 +177,26 @@ class TenderJIT
       Fiddle.read_ptr(ep, VM_ENV_DATA_INDEX_SPECVAL * Fiddle::SIZEOF_VOIDP)
     end
 
+    def vm_block_handler_type bh_ptr
+      # https://github.com/ruby/ruby/blob/cbf2078a25c3efb12f45b643a636ff7bb4d402b6/vm_core.h#L1511-L1512
+
+      # 0b...01 # ISeq block handler
+      # 0b...11 # IFunc block handler
+      if VM_BH_ISEQ_BLOCK_P(bh_ptr)
+        c("block_handler_type_iseq")
+      elsif VM_BH_IFUNC_P(bh_ptr)
+        c("block_handler_type_ifunc")
+      elsif RB_SYMBOL_P(bh_ptr)
+        c("block_handler_type_symbol")
+      else
+        c("block_handler_type_proc")
+      end
+    end
+
+    def VM_BH_IFUNC_P bh
+      bh & 0x03 == 0x03
+    end
+
     def VM_BH_ISEQ_BLOCK_P bh
       bh & 0x03 == 0x01
     end

--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -522,6 +522,8 @@ class TenderJIT
           @fisk.mov(Fisk::Registers::CALLER_SAVED[i], param)
         when TemporaryVariable
           @fisk.mov(Fisk::Registers::CALLER_SAVED[i], param.to_register)
+        when Proc
+          param.call Fisk::Registers::CALLER_SAVED[i]
         else
           raise NotImplementedError
         end

--- a/test/instructions/getblockparam_test.rb
+++ b/test/instructions/getblockparam_test.rb
@@ -24,8 +24,7 @@ class TenderJIT
       jit.disable!
 
       assert_equal 2, jit.compiled_methods
-      assert_equal 2, jit.exits
-      refute_includes jit.exit_stats.find_all { |x,y| y > 0 }.map(&:first), :getblockparam
+      assert_equal 0, jit.exits
       assert_equal expected, actual
     end
   end

--- a/test/instructions/getblockparamproxy_test.rb
+++ b/test/instructions/getblockparamproxy_test.rb
@@ -4,8 +4,73 @@ require "helper"
 
 class TenderJIT
   class GetblockparamproxyTest < JITTest
-    def test_getblockparamproxy
-      skip "Please implement getblockparamproxy!"
+    def takes_symbol &blk
+      blk.call 1
+    end
+
+    def test_getblockparamproxy_static_symbol
+      assert_has_insn method(:takes_symbol), insn: :getblockparamproxy
+      expected = takes_symbol(&:nil?)
+
+      jit.compile(method(:takes_symbol))
+
+      jit.enable!
+      takes_symbol(&:nil?)
+      actual = takes_symbol(&:nil?)
+      jit.disable!
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.exits
+      assert_equal expected, actual
+    end
+
+    class Foo
+      x = "omgomgomg"
+      define_method :"omg#{x}?" do
+        "cool"
+      end
+    end
+
+    def takes_symbol2 m, &blk
+      blk.call m
+    end
+
+    def test_getblockparamproxy_dynamic_symbol
+      assert_has_insn method(:takes_symbol2), insn: :getblockparamproxy
+      x = "omgomgomg"
+      expected = takes_symbol2(Foo.new, &:"omg#{x}?")
+
+      jit.compile(method(:takes_symbol2))
+
+      jit.enable!
+      takes_symbol2(Foo.new, &:"omg#{x}?")
+      actual = takes_symbol2(Foo.new, &:"omg#{x}?")
+      jit.disable!
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.exits
+      assert_equal expected, actual
+    end
+
+    def takes_iseq &blk
+      blk.call
+    end
+
+    def test_getblockparamproxy_iseq
+      assert_has_insn method(:takes_iseq), insn: :getblockparamproxy
+      expected = takes_iseq { "foo" }
+
+      jit.compile(method(:takes_iseq))
+
+      jit.enable!
+      takes_iseq { "foo" }
+      actual = takes_iseq { "foo" }
+      jit.disable!
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 2, jit.exits
+      refute_includes jit.exit_stats.find_all { |x,y| y > 0 }.map(&:first), :getblockparamproxy
+      assert_equal expected, actual
     end
   end
 end

--- a/test/instructions/send_test.rb
+++ b/test/instructions/send_test.rb
@@ -105,5 +105,27 @@ class TenderJIT
       assert_equal 0, jit.exits
       assert_equal expected, actual
     end
+    def block_takes_iseq_block &blk
+      m = nil
+      [1, 1].each do
+        m = blk.call(2) { "neat" }
+      end
+      m
+    end
+
+    def test_block_takes_block
+      expected = block_takes_iseq_block { |_, &blk| blk.call }
+
+      jit.compile(method(:block_takes_iseq_block))
+
+      jit.enable!
+      actual = block_takes_iseq_block { |_, &blk| blk.call }
+      jit.disable!
+
+      assert_equal 2, jit.compiled_methods
+      assert_equal 0, jit.exits
+      assert_equal expected, actual
+    end
+
   end
 end


### PR DESCRIPTION
I think there's an opportunity for us to compile block iseqs eagerly in here.  I think getblockparamproxy can find the iseq for the block and we can tell the JIT to compile that block.  This PR doesn't do it though.