### PR TITLE
Implement `intern` instruction (shallow)

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -1541,6 +1541,17 @@ class TenderJIT
       end
     end
 
+    def handle_intern
+      rb_str_intern = Fiddle::Handle::DEFAULT["rb_str_intern"]
+
+      str = @temp_stack.pop
+
+      with_runtime do |rt|
+        rt.call_cfunc rb_str_intern, [str]
+        rt.push rt.return_value, name: RUBY_T_SYMBOL
+      end
+    end
+
     class BranchUnless < Struct.new(:jump_idx, :jump_type, :temp_stack)
     end
 

--- a/test/instructions/intern_test.rb
+++ b/test/instructions/intern_test.rb
@@ -32,8 +32,6 @@ class TenderJIT
     end
 
     def test_new_symbol
-      skip "Please implement intern!"
-
       jit.compile method(:new_symbol)
       assert_equal 1, jit.compiled_methods
       assert_equal 0, jit.executed_methods
@@ -50,8 +48,6 @@ class TenderJIT
     end
 
     def test_existing_symbol
-      skip "Please implement intern!"
-
       jit.compile method(:existing_symbol)
       assert_equal 1, jit.compiled_methods
       assert_equal 0, jit.executed_methods


### PR DESCRIPTION
Shallow implementation of the `intern` instruction.

The invoked function (`symbol.c#rb_str_intern`) actually may be tricky, as there's a conditional (`USE_SYMBOL_GC`) implementation.