### PR TITLE
Refinements to `make_warnings_errors`, and two cleanups

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -387,7 +387,6 @@ class TenderJIT
       param_size = iseq.body.param.size
       local_size = iseq.body.local_table_size
       opt_pc     = 0 # we don't handle optional parameters rn
-      argc       = ci.vm_ci_argc
 
       method_entry_addr = jit_buffer.address
 
@@ -1079,13 +1078,6 @@ class TenderJIT
 
     def compile_call_cfunc iseq, req, argc, iseq_ptr, recv, cme, return_loc
       cfunc = RbMethodDefinitionStruct.new(cme.def).body.cfunc
-      param_size = if cfunc.argc == -1
-                     argc
-                   elsif cfunc.argc < 0
-                     raise NotImplementedError
-                   else
-                     cfunc.argc
-                   end
 
       temp_stack = req.temp_stack
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,11 +1,11 @@
 ENV["MT_NO_PLUGINS"] = "1"
 
 require "minitest/autorun"
+require "make_warnings_errors"
 require "tenderjit"
 require "rbconfig"
 require "fisk"
 require "fisk/helpers"
-require "make_warnings_errors"
 
 class TenderJIT
   class Test < Minitest::Test

--- a/test/make_warnings_errors.rb
+++ b/test/make_warnings_errors.rb
@@ -6,6 +6,7 @@ raise "In order to make errors into warnings, ensure that $VERBOSE is set!" unle
 # Make errors into warnings (gcc's -W)
 # This is somewhat odd, but it's been officially accepted for this purpose (see https://bugs.ruby-lang.org/issues/3916).
 module Warning
+  undef :warn
   def warn msg
     raise msg
   end

--- a/test/make_warnings_errors.rb
+++ b/test/make_warnings_errors.rb
@@ -1,6 +1,10 @@
+# With $VERBOSE unset, warnings, and in turn errors, are not raised.
+# Interestingly, as of v3.0.0, the documentation does not mention the case where
+# $VERBOSE is false.
+raise "In order to make errors into warnings, ensure that $VERBOSE is set!" unless $VERBOSE
+
 # Make errors into warnings (gcc's -W)
 # This is somewhat odd, but it's been officially accepted for this purpose (see https://bugs.ruby-lang.org/issues/3916).
-#
 module Warning
   def warn msg
     raise msg


### PR DESCRIPTION
Minor improvements to `make_warnings_errors`:

- Require it earlier, to catch more warnings
- Ensure that $VERBOSE is set: nice to have
- Undefine :warn: avoid a warning

Also, removed two unused variables from inside ISEQCompiler.