### PR TITLE
Pass blocks to blocks

### DIFF
--- a/lib/tenderjit.rb
+++ b/lib/tenderjit.rb
@@ -67,6 +67,47 @@ class TenderJIT
       end
     end
 
+    # Return a list of VM_CALL_* flags that are set on this call info object
+    def vm_call_flags
+      ci_flags = vm_ci_flag
+
+      [
+        :VM_CALL_ARGS_SPLAT,
+        :VM_CALL_ARGS_BLOCKARG,
+        :VM_CALL_FCALL,
+        :VM_CALL_VCALL,
+        :VM_CALL_ARGS_SIMPLE,
+        :VM_CALL_BLOCKISEQ,
+        :VM_CALL_KW_SPLAT,
+        :VM_CALL_TAILCALL,
+        :VM_CALL_SUPER,
+        :VM_CALL_ZSUPER,
+        :VM_CALL_OPT_SEND,
+        :VM_CALL_KW_SPLAT_MUT,
+        :VM_CALL_KWARG
+      ].find_all { |n| ci_flags & TenderJIT.const_get(n) == TenderJIT.const_get(n) }
+    end
+
+    # Can we support this type of call in the JIT?
+    def supported_call?
+      unhandled = [VM_CALL_ARGS_SPLAT,
+                   #VM_CALL_ARGS_BLOCKARG,
+                   #VM_CALL_FCALL,
+                   #VM_CALL_VCALL,
+                   #VM_CALL_ARGS_SIMPLE,
+                   #VM_CALL_BLOCKISEQ,
+                   VM_CALL_KW_SPLAT,
+                   VM_CALL_TAILCALL,
+                   VM_CALL_SUPER,
+                   VM_CALL_ZSUPER,
+                   #VM_CALL_OPT_SEND,
+                   VM_CALL_KW_SPLAT_MUT,
+                   VM_CALL_KWARG
+      ].inject(0) { |acc, bit| acc | bit }
+
+      vm_ci_flag & unhandled == 0
+    end
+
     def vm_ci_mid
       if vm_ci_packed?
         (to_i >> CI_EMBED_ID_SHFT) & CI_EMBED_ID_MASK

--- a/lib/tenderjit/c_funcs.rb
+++ b/lib/tenderjit/c_funcs.rb
@@ -37,6 +37,7 @@ class TenderJIT
     make_function "rb_intern", [TYPE_CONST_STRING], TYPE_INT
     make_function "rb_id2sym", [TYPE_INT], TYPE_VOIDP
     make_function "rb_id2str", [TYPE_INT], TYPE_VOIDP
+    make_function "rb_sym2id", [TYPE_VOIDP], TYPE_INT
     make_function "memset", [TYPE_VOIDP, TYPE_INT, TYPE_SIZE_T], TYPE_VOID
     make_function "rb_st_lookup", [TYPE_VOIDP, TYPE_VOIDP, TYPE_VOIDP], TYPE_INT
     make_function "rb_ivar_set", [TYPE_VOIDP, TYPE_INT, TYPE_VOIDP], TYPE_VOIDP
@@ -44,5 +45,6 @@ class TenderJIT
     make_function "rb_iseq_path", [TYPE_VOIDP], TYPE_VOIDP
     make_function "rb_iseq_label", [TYPE_VOIDP], TYPE_VOIDP
     make_function "rb_obj_class", [TYPE_VOIDP], TYPE_VOIDP
+    make_function "rb_method_basic_definition_p", [TYPE_VOIDP, TYPE_INT], TYPE_INT
   end
 end

--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -2043,13 +2043,13 @@ class TenderJIT
 
     def handle_putobject_INT2FIX_1_
       with_runtime do |rt|
-        rt.push Fisk::Imm64.new(0x3), name: T_FIXNUM
+        rt.push Fisk::Imm64.new(0x3), name: 1, type: T_FIXNUM
       end
     end
 
     def handle_putobject_INT2FIX_0_
       with_runtime do |rt|
-        rt.push Fisk::Imm64.new(0x1), name: T_FIXNUM
+        rt.push Fisk::Imm64.new(0x1), name: 0, type: T_FIXNUM
       end
     end
 
@@ -2146,20 +2146,10 @@ class TenderJIT
     end
 
     def handle_putobject literal
-      object_name = if rb.RB_FIXNUM_P(literal)
-              T_FIXNUM
-            elsif literal == Qtrue
-              true
-            elsif literal == Qfalse
-              false
-            elsif rb.RB_SYMBOL_P(literal)
-              T_SYMBOL
-            else
-              :unknown
-            end
+      object_type = rb.rb_type literal
 
       with_runtime do |rt|
-        rt.push literal, name: object_name, type: object_name
+        rt.push literal, name: :literal, type: object_type
       end
     end
 

--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -373,7 +373,7 @@ class TenderJIT
       method_entry_addr
     end
 
-    def compile_invokeblock_iseq_handler iseq_ptr, captured, return_loc, patch_loc, req
+    def compile_invokeblock_iseq_handler iseq_ptr, captured, return_loc, req, temp_stack
       temp_stack = req.temp_stack
 
       ci = req.call_info
@@ -458,8 +458,6 @@ class TenderJIT
         var.release!
       end
 
-      patch_source_jump jit_buffer, at: patch_loc, to: method_entry_addr
-
       method_entry_addr
     end
 
@@ -480,7 +478,9 @@ class TenderJIT
         iseq_ptr = captured.code.iseq
         @jit.compile_iseq_t iseq_ptr
 
-        compile_invokeblock_iseq_handler iseq_ptr, captured, return_loc, patch_loc, req
+        method_entry_addr = compile_invokeblock_iseq_handler iseq_ptr, captured, return_loc, req, req.temp_stack
+        patch_source_jump jit_buffer, at: patch_loc, to: method_entry_addr
+        method_entry_addr
       else
         raise NotImplementedError
         # TODO: need to implement vm_block_handler_type

--- a/lib/tenderjit/ruby.rb
+++ b/lib/tenderjit/ruby.rb
@@ -242,6 +242,29 @@ class TenderJIT
       RBasic.flags(obj_addr) & RUBY_T_MASK
     end
 
+    # Basically the same as RB_BUILTIN_TYPE but handles special consts.
+    def rb_type obj_addr
+      if RB_SPECIAL_CONST_P(obj_addr)
+        case obj_addr
+        when Qfalse then Ruby::T_FALSE
+        when Qnil   then Ruby::T_NIL
+        when Qtrue  then Ruby::T_TRUE
+        else
+          if self.RB_FIXNUM_P obj_addr
+            Ruby::T_FIXNUM
+          elsif self.RB_STATIC_SYM_P obj_addr
+            Ruby::T_SYMBOL
+          elsif self.RB_FLONUM_P obj_addr
+            Ruby::T_FLOAT
+          else
+            raise "Unexpected type!"
+          end
+        end
+      else
+        RB_BUILTIN_TYPE(obj_addr)
+      end
+    end
+
     def rb_current_vm
       Fiddle.read_ptr Ruby::SYMBOLS["ruby_current_vm_ptr"], 0
     end

--- a/lib/tenderjit/temp_stack.rb
+++ b/lib/tenderjit/temp_stack.rb
@@ -2,7 +2,15 @@
 
 class TenderJIT
   class TempStack
-    Item = Struct.new(:name, :type, :loc)
+    class Item < Struct.new(:name, :type, :loc)
+      def symbol?
+        type == Ruby::T_SYMBOL
+      end
+
+      def fixnum?
+        type == Ruby::T_FIXNUM
+      end
+    end
 
     def initialize
       @stack = []

--- a/test/instructions/getblockparamproxy_test.rb
+++ b/test/instructions/getblockparamproxy_test.rb
@@ -67,9 +67,8 @@ class TenderJIT
       actual = takes_iseq { "foo" }
       jit.disable!
 
-      assert_equal 1, jit.compiled_methods
-      assert_equal 2, jit.exits
-      refute_includes jit.exit_stats.find_all { |x,y| y > 0 }.map(&:first), :getblockparamproxy
+      assert_equal 2, jit.compiled_methods
+      assert_equal 0, jit.exits
       assert_equal expected, actual
     end
   end

--- a/test/instructions/send_test.rb
+++ b/test/instructions/send_test.rb
@@ -105,6 +105,7 @@ class TenderJIT
       assert_equal 0, jit.exits
       assert_equal expected, actual
     end
+
     def block_takes_iseq_block &blk
       m = nil
       [1, 1].each do
@@ -127,5 +128,22 @@ class TenderJIT
       assert_equal expected, actual
     end
 
+    def block_takes_sym_block &blk
+      blk.call(&:nil?)
+    end
+
+    def test_block_takes_sym_block
+      expected = block_takes_sym_block { |&blk| blk }
+
+      jit.compile(method(:block_takes_sym_block))
+
+      jit.enable!
+      actual = block_takes_sym_block { |&blk| blk }
+      jit.disable!
+
+      assert_equal expected, actual
+      assert_equal 2, jit.compiled_methods
+      assert_equal 0, jit.exits
+    end
   end
 end

--- a/test/ruby_internals_test.rb
+++ b/test/ruby_internals_test.rb
@@ -181,11 +181,8 @@ class TenderJIT
 
     def test_constant_body_size
       rb_iseq_constant_body = rb.struct("rb_iseq_constant_body")
-      if RubyVM.const_defined?(:YJIT)
-        assert_equal 304, rb_iseq_constant_body.byte_size
-      else
-        assert_equal 288, rb_iseq_constant_body.byte_size
-      end
+      # This seemed to get bigger after YJIT merged
+      assert_operator rb_iseq_constant_body.byte_size, :>=, 288
     end
 
     def omg2; end

--- a/test/ruby_internals_test.rb
+++ b/test/ruby_internals_test.rb
@@ -10,6 +10,16 @@ class TenderJIT
       @rb = Ruby::INSTANCE
     end
 
+    def test_builtin_type
+      assert_equal Ruby::T_OBJECT, rb.rb_type(Fiddle.dlwrap(Object.new))
+      assert_equal Ruby::T_DATA, rb.rb_type(Fiddle.dlwrap(lambda {}))
+      assert_equal Ruby::T_FIXNUM, rb.rb_type(Fiddle.dlwrap(1))
+      assert_equal Ruby::T_TRUE, rb.rb_type(Fiddle.dlwrap(true))
+      assert_equal Ruby::T_FALSE, rb.rb_type(Fiddle.dlwrap(false))
+      assert_equal Ruby::T_NIL, rb.rb_type(Fiddle.dlwrap(nil))
+      assert_equal Ruby::T_SYMBOL, rb.rb_type(Fiddle.dlwrap(:foo))
+    end
+
     def test_RB_SYMBOL_P
       assert rb.RB_SYMBOL_P(Fiddle.dlwrap(:foo))
       assert rb.RB_SYMBOL_P(Fiddle.dlwrap(:"foo#{1234}"))

--- a/test/temp_stack_test.rb
+++ b/test/temp_stack_test.rb
@@ -3,6 +3,18 @@
 require "helper"
 
 class TempStackTest < TenderJIT::Test
+  def test_push_symbol
+    stack = TenderJIT::TempStack.new
+    stack.push :foo, type: TenderJIT::T_SYMBOL
+    assert_predicate stack.peek(0), :symbol?
+  end
+
+  def test_push_fixnum
+    stack = TenderJIT::TempStack.new
+    stack.push 123, type: TenderJIT::T_FIXNUM
+    assert_predicate stack.peek(0), :fixnum?
+  end
+
   def test_push_then_read_with_square
     stack = TenderJIT::TempStack.new
     stack.push("name")


### PR DESCRIPTION
This PR has a few mostly "refactoring" changes, but the main point is the last commit that supports passing blocks to blocks.  So we can compile blocks like `lambda { |&blk| ... }` now.