### PR TITLE
Implement handle_opt_not

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -2142,6 +2142,10 @@ class TenderJIT
       compare_fixnum { |reg0, reg1| __.cmovle(reg0, reg1) }
     end
 
+    def handle_opt_not call_data
+      handle_opt_send_without_block call_data
+    end
+
     def handle_opt_succ call_data
       value = @temp_stack.peek(0).loc
 

--- a/test/instructions/opt_not_test.rb
+++ b/test/instructions/opt_not_test.rb
@@ -4,8 +4,80 @@ require "helper"
 
 class TenderJIT
   class OptNotTest < JITTest
-    def test_opt_not
-      skip "Please implement opt_not!"
+    def not_false
+      !false
+    end
+
+    def test_opt_not_false
+      jit.compile method(:not_false)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      v = not_false
+      jit.disable!
+      assert_equal true, v
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
+    def not_nil
+      !nil
+    end
+
+    def test_opt_not_nil
+      jit.compile method(:not_nil)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      v = not_nil
+      jit.disable!
+      assert_equal true, v
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
+    def not_true
+      !true
+    end
+
+    def test_opt_not_true
+      jit.compile method(:not_true)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      v = not_true
+      jit.disable!
+      assert_equal false, v
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
+    def not_array
+      ![]
+    end
+
+    def test_opt_not_array
+      jit.compile method(:not_array)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      v = not_array
+      jit.disable!
+      assert_equal false, v
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
     end
   end
 end

--- a/test/instructions/opt_send_without_block_test.rb
+++ b/test/instructions/opt_send_without_block_test.rb
@@ -52,7 +52,7 @@ class TenderJIT
 
       assert_equal 1, jit.compiled_methods
       assert_equal 1, jit.executed_methods
-      assert_equal 1, jit.exits
+      assert_equal 0, jit.exits
     end
 
     def call_bang
@@ -73,7 +73,7 @@ class TenderJIT
 
       assert_equal 1, jit.compiled_methods
       assert_equal 1, jit.executed_methods
-      assert_equal 1, jit.exits
+      assert_equal 0, jit.exits
     end
 
     def one
@@ -98,7 +98,7 @@ class TenderJIT
 
       assert_equal 2, jit.compiled_methods
       assert_equal 2, jit.executed_methods
-      assert_equal 1, jit.exits
+      assert_equal 0, jit.exits
     end
 
     def cfunc x


### PR DESCRIPTION
This implements the opt_not instruction to prevent side exits. We based this off of the YJIT implementation, which just delegates to "send without block": https://github.com/ruby/ruby/blob/d48f5082e5b5af56bc9a0986eb83bb18520f4233/yjit_codegen.c#L2613-L2617

Co-authored-by: Blake Williams <blakewilliams@github.com>