### PR TITLE
Fix Ruby master support

### DIFF
--- a/test/instructions/checktype_test.rb
+++ b/test/instructions/checktype_test.rb
@@ -15,6 +15,8 @@ class TenderJIT
     def test_checktype
       m = method(:interpolation)
       iseq = RubyVM::InstructionSequence.of(m)
+      return skip unless iseq.to_a.flatten.include?(:checktype)
+
       assert_includes iseq.to_a.flatten, :checktype
 
       jit.compile m

--- a/test/instructions/tostring_test.rb
+++ b/test/instructions/tostring_test.rb
@@ -18,6 +18,11 @@ class TenderJIT
       "#{:a}"
     end
 
+    def setup
+      super
+      return skip unless RubyVM::INSTRUCTION_NAMES.include?("tostring")
+    end
+
     def test_tostring
       meth = method(:tostring)
 


### PR DESCRIPTION
Ruby master has a few new instructions we need to implement and it also
changed the layout of RbMethodDefinitionStruct.  This commit just
catches up with those changes.