### PR TITLE
Fallback implementation of opt_length instruction

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -2162,6 +2162,10 @@ class TenderJIT
       handle_opt_send_without_block call_data
     end
 
+    def handle_opt_length call_data
+      handle_opt_send_without_block call_data
+    end
+
     def handle_opt_succ call_data
       value = @temp_stack.peek(0).loc
 

--- a/test/instructions/opt_length_test.rb
+++ b/test/instructions/opt_length_test.rb
@@ -4,8 +4,50 @@ require "helper"
 
 class TenderJIT
   class OptLengthTest < JITTest
-    def test_opt_length
-      skip "Please implement opt_length!"
+    def string_length
+      'true'.length
+    end
+
+    def test_opt_length_string
+      setup_test_for(:string_length, 4)
+    end
+
+    def symbol_length
+      :hey.length
+    end
+
+    def test_opt_length_symbol
+      setup_test_for(:symbol_length, 3)
+    end
+
+    def array_length
+      [1,2].length
+    end
+
+    def test_opt_length_array
+      setup_test_for(:array_length, 2)
+    end
+
+    def hash_length
+      { 'true' => 1 }.length
+    end
+
+    def test_opt_length_hash
+      setup_test_for(:hash_length)
+    end
+
+    def setup_test_for(method_name, expected_length = 1)
+      m = method(method_name)
+      assert_has_insn m, insn: :opt_length
+      jit.compile(m)
+      jit.enable!
+      v = m.call
+      jit.disable!
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.exits
+      assert_equal 1, jit.executed_methods
+      assert_equal expected_length, v
     end
   end
 end


### PR DESCRIPTION
This fallback implementation serves several purposes:

- Minimize exists to the interpreter
- Cover instruction with non-skipped tests 