### PR TITLE
Extend Runtime test suite functionality (and add supporting changes)

### DIFF
--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -307,6 +307,10 @@ class TenderJIT
       end
     end
 
+    def movsd reg, source
+      @fisk.movsd reg, cast_to_fisk(source)
+    end
+
     def break
       @fisk.int(@fisk.lit(3))
     end

--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -533,8 +533,6 @@ class TenderJIT
 
       val = cast_to_fisk val
 
-      @cfunc_call_stack_depth += val.size / 8
-
       if val.memory? || val.immediate?
         write loc, val
       else

--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -551,7 +551,11 @@ class TenderJIT
       end
     end
 
-    def call_cfunc func_loc, params, auto_align: true
+    # options:
+    #  :call_reg: Specify an alternate register for the (long) function call; defaults
+    #             to RAX.
+    #
+    def call_cfunc func_loc, params, auto_align: true, call_reg: Fisk::Registers::RAX
       raise NotImplementedError, "too many parameters" if params.length > 6
       raise "No function location" unless func_loc > 0
 
@@ -570,8 +574,10 @@ class TenderJIT
             raise NotImplementedError
           end
         end
-        @fisk.mov(@fisk.rax, @fisk.uimm(func_loc))
-          .call(@fisk.rax)
+
+        @fisk.mov(call_reg, @fisk.uimm(func_loc))
+          .call(call_reg)
+
         @fisk.rax
       end
     end

--- a/test/registers_saving_buffer.rb
+++ b/test/registers_saving_buffer.rb
@@ -58,6 +58,16 @@ class RegistersSavingBuffer < Fisk::Helpers::JITBuffer
     register_values.fetch reg.name
   end
 
+  # Convenience methods.
+  #
+  SAVED_REGISTERS.each do |reg|
+    class_eval <<~RUBY, __FILE__, __LINE__ + 1
+      def saved_#{reg.name}
+        register_values.fetch #{reg.name.inspect}
+      end
+    RUBY
+  end
+
   # List of "register_name: hex_value"
   #
   # arguments:

--- a/test/registers_saving_buffer.rb
+++ b/test/registers_saving_buffer.rb
@@ -5,8 +5,8 @@ require "fisk/helpers"
 
 include Fisk::Registers
 
-# A transparent wrapper around a JIT buffer, that, after the JIT buffer is executed,
-# saves the registers content to a separate location, so that they can be tested.
+# A JIT buffer that, after execution, saves the registers content to a separate
+# location, so that they can be tested.
 #
 # In order to use:
 #
@@ -16,9 +16,11 @@ include Fisk::Registers
 #     saving_buffer.to_function([], Fiddle::TYPE_VOID).call
 #     assert_equal 1, saving_buffer.register_value(RAX)
 #
+# The design can easily be turned into a proxy around a JIT Buffer, if needed.
+#
 class RegistersSavingBuffer < Fisk::Helpers::JITBuffer
   # In push order, which is the reverse order of storage/read. RSP +must+ be the
-  # first, as it needs manual correction.
+  # first, in order to store the original value.
   #
   SAVED_REGISTERS = [RSP, R15, R14, R13, R12, R11, R10, R9, R8, RBP, RSI, RDI, RDX, RCX, RBX, RAX]
 

--- a/test/registers_saving_buffer_test.rb
+++ b/test/registers_saving_buffer_test.rb
@@ -1,0 +1,54 @@
+require "helper"
+
+class TenderJIT
+  class RegistersSavingBufferTest < Test
+    def prepare_buffer
+      fisk = Fisk.new
+
+      buffer = RegistersSavingBuffer.new Fisk::Helpers.mmap_jit(4096), 4096
+
+      fisk.asm(buffer) do
+        # Avoid messing with RSP/RBP
+        mov RAX, fisk.imm64(0x02_03_04_05)
+        mov RBX, fisk.imm64(0x03_04_05_06)
+        mov RCX, fisk.imm64(0x04_05_06_07)
+        mov RDX, fisk.imm64(0x05_06_07_08)
+        mov RSI, fisk.imm64(0x06_07_08_09)
+        mov RDI, fisk.imm64(0x07_08_09_10)
+        mov R8,  fisk.imm64(0x09_10_11_12)
+        mov R9,  fisk.imm64(0x10_11_12_13)
+        mov R10, fisk.imm64(0x11_12_13_14)
+        mov R11, fisk.imm64(0x12_13_14_15)
+        mov R12, fisk.imm64(0x13_14_15_16)
+        mov R13, fisk.imm64(0x14_12_10_08)
+        mov R14, fisk.imm64(0x15_13_11_09)
+        mov R15, fisk.imm64(0xde_ad_ca_fe)
+
+        ret
+      end
+
+      buffer
+    end
+
+    def test_saving
+      buffer = prepare_buffer
+
+      buffer.to_function([], Fiddle::TYPE_VOID).call
+
+      assert_equal buffer.saved_rax, 0x02_03_04_05
+      assert_equal buffer.saved_rbx, 0x03_04_05_06
+      assert_equal buffer.saved_rcx, 0x04_05_06_07
+      assert_equal buffer.saved_rdx, 0x05_06_07_08
+      assert_equal buffer.saved_rsi, 0x06_07_08_09
+      assert_equal buffer.saved_rdi, 0x07_08_09_10
+      assert_equal buffer.saved_r8,  0x09_10_11_12
+      assert_equal buffer.saved_r9,  0x10_11_12_13
+      assert_equal buffer.saved_r10, 0x11_12_13_14
+      assert_equal buffer.saved_r11, 0x12_13_14_15
+      assert_equal buffer.saved_r12, 0x13_14_15_16
+      assert_equal buffer.saved_r13, 0x14_12_10_08
+      assert_equal buffer.saved_r14, 0x15_13_11_09
+      assert_equal buffer.saved_r15, 0xde_ad_ca_fe
+    end
+  end # RegistersSavingBufferTest
+end # TenderJIT

--- a/test/runtime_test.rb
+++ b/test/runtime_test.rb
@@ -18,16 +18,35 @@ class TenderJIT
       @rt = Runtime::new(fisk, @saving_buffer, temp_stack)
     end
 
-    # Smoke test.
-    #
-    def test_if_eq_imm_imm64
-      rt.if_eq(2 << 0, 2 << 32)
+    def test_if_eq_imm8_imm64_false_branch
+      rt.if_eq(2 << 0, 2 << 32) {
+        rt.write RAX, 1
+      }.else {
+        rt.write RAX, 2
+      }
+
+      rt.return
+      rt.write!
+      saving_buffer.to_function([], Fiddle::TYPE_VOID).call
+
+      assert_equal 2, saving_buffer.register_value(RAX)
     end
 
-    # Smoke test.
+    # Originally design to verify comparing an imm8 with an immediate less than
+    # 64 bits wide (this UT therefore tests two things).
     #
-    def test_if_eq_imm_immnot64
-      rt.if_eq(2 << 0, 2 << 0)
+    def test_if_eq_imm8_imm8_true_branch
+      rt.if_eq(2 << 0, 2 << 0) {
+        rt.write RAX, 1
+      }.else {
+        rt.write RAX, 2
+      }
+
+      rt.return
+      rt.write!
+      saving_buffer.to_function([], Fiddle::TYPE_VOID).call
+
+      assert_equal 1, saving_buffer.register_value(RAX)
     end
 
     # See https://github.com/tenderlove/tenderjit/issues/35#issuecomment-934872857
@@ -46,8 +65,8 @@ class TenderJIT
     def test_inc
       rt.xor RAX, RAX
       rt.inc RAX
-      rt.return
 
+      rt.return
       rt.write!
       saving_buffer.to_function([], Fiddle::TYPE_VOID).call
 


### PR DESCRIPTION
Make RegistersSavingBuffer entirely transparent, by avoid using a CALL (previously, it could be used for toy functions only).

With this functionality, the Runtime class can now be fully tested (excluding Ruby calls). A working UT for automatic cfunc call alignment has been added (without alignment, it will fail), and a few UTs (`if_eq*`) have been extended to actually test the instruction.

Commits to consider carefully are:

1. Runtime: Remove inappropriate @cfunc_call_stack_depth adjustment in push()

I think this was wrong.

2. Fix the Runtime autoalignment logic

My interpretation of alignment was incorrect (I'm an x64 n00b 😅); alignment does *not* need to take into account that the RIP is pushed.

This previously worked because Runtime starts with an unaligned stack (so that it compensated for the incorrect conditional). It's actually not clear to me why is so, so I'm taking it as a fact.

Other minor changes are present; the comments update commit is here just because I've pushed the previous PR from the wrong machine (🤦).

Ah, I'm going to add the autoalignment failure test case (assert raises...) in a separate PR; it's not trivial.