### PR TITLE
Runtime: Save temp var registers before calling cfuncs

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -810,11 +810,11 @@ class TenderJIT
 
             # We know it's an array at compile time
             if klass == ::Array
-              rt.call_cfunc rb.symbol_address("rb_ary_aref1"), [recv, param], auto_align: false
+              rt.call_cfunc rb.symbol_address("rb_ary_aref1"), [recv, param], auto_align: false, preserve_tempvars: false
 
               # We know it's a hash at compile time
             elsif klass == ::Hash
-              rt.call_cfunc rb.symbol_address("rb_hash_aref"), [recv, param], auto_align: false
+              rt.call_cfunc rb.symbol_address("rb_hash_aref"), [recv, param], auto_align: false, preserve_tempvars: false
 
             else
               raise NotImplementedError

--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -1657,13 +1657,8 @@ class TenderJIT
             rt.call_cfunc rb_ary_tmp_new_from_values, [0, cnt, stack_addr_from_top]
             ary.write rt.return_value
 
-            # Store and use for alignment.
-            rt.push_reg ary
-
-            rt.call_cfunc rb_reg_new_ary, [ary, opt], auto_align: false
+            rt.call_cfunc rb_reg_new_ary, [ary, opt]
             rt.write result, rt.return_value
-
-            rt.pop_reg ary
 
             rt.call_cfunc rb_ary_clear, [ary]
           end

--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -800,11 +800,11 @@ class TenderJIT
       if !auto_align || @cfunc_call_stack_depth % 16 == 0
         yield
       else
-        @fisk.push REG_BP.to_register
+        self.push_reg REG_BP
 
         result = yield
 
-        @fisk.pop REG_BP.to_register
+        self.pop_reg REG_BP
 
         result
       end

--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -710,7 +710,7 @@ class TenderJIT
 
       if block_given?
         yield tv
-        tv.release!
+        self.release_temp(tv)
       else
         tv
       end

--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -719,13 +719,13 @@ class TenderJIT
     # Push a register on the machine stack
     def push_reg reg
       @fisk.push reg.to_register
-      @cfunc_call_stack_depth += reg.size
+      @cfunc_call_stack_depth += reg.to_register.size / 8
     end
 
     # Pop a register on the machine stack
     def pop_reg reg
       @fisk.pop reg.to_register
-      @cfunc_call_stack_depth -= reg.size
+      @cfunc_call_stack_depth -= reg.to_register.size / 8
     end
 
     def return


### PR DESCRIPTION
Save the temp var registers before calling cfuncs. Previously, they would just be overwritten.

For simplicity, this version has an option to disable automatic preservation, in order to address the topic described [in this comment](https://github.com/tenderlove/tenderjit/pull/101#issuecomment-993011515). The big-picture (`RBP` handling) issue will be handled separately.

Closes #83.

Besides a couple of (minor) cleanups, there is also a [fix](https://github.com/tenderlove/tenderjit/pull/101/commits/09b6116251a221248f55d58bec5cbc01077441a1).