### PR TITLE
Implement the `expandarray` instruction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "crabstone"
 gem "fiddle", git: "https://github.com/ruby/fiddle.git"
 gem "worf", git: "https://github.com/tenderlove/worf.git"
 gem "fisk", git: "https://github.com/tenderlove/fisk.git"

--- a/lib/tenderjit.rb
+++ b/lib/tenderjit.rb
@@ -21,6 +21,7 @@ class TenderJIT
   # Struct layouts
 
   RBasic                = Internals.struct("RBasic")
+  RArray                = Internals.struct("RArray")
   RClass                = Internals.struct("RClass")
 
   RObject               = Internals.struct("RObject")

--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -2715,10 +2715,7 @@ class TenderJIT
               rt.jump jit_buffer.memory.to_i + return_loc
             }
           else
-            rt.if_embedded_array?(stack_top) {
-              # recompile
-              rt.break
-            }.else {
+            rt.if_extended_array?(stack_top) {
               rt.temp_var do |tmp|
                 # Write the array length in to the `len` register
                 rt.extended_array_length(stack_top, tmp)
@@ -2738,6 +2735,11 @@ class TenderJIT
                   rt.break
                 }
               end
+            }.else {
+              # recompile
+              rt.patchable_jump req.deferred_entry
+              # FIXME: see above
+              rt.jump jit_buffer.memory.to_i + return_loc
             }
           end
         else

--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -2706,7 +2706,13 @@ class TenderJIT
               end
             }.else {
               # recompile
-              rt.break
+              rt.patchable_jump req.deferred_entry
+
+              # FIXME: It's weird that as we compile things we'll have to jump
+              # back here, then jump back to the origin.  It would be nice to
+              # directly jump back to the origin.  I need to figure out a way
+              # to do that.
+              rt.jump jit_buffer.memory.to_i + return_loc
             }
           else
             rt.if_embedded_array?(stack_top) {

--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -2664,6 +2664,67 @@ class TenderJIT
     class CompileExpandArray < Struct.new(:num, :flag, :temp_stack, :deferred_entry)
     end
 
+    def compile_embedded_expandarray rt, req, tmp, stack_top
+      rt.temp_var { |tmp2|
+        rt.temp_var { |stack|
+          # Push the array reference on the stack so we can get it again later
+          rt.push_reg tmp
+
+          rt.embedded_array_length(tmp, tmp)
+
+          rt.if(tmp, :>=, req.num) {
+            # Get the array back
+            rt.pop_reg tmp
+
+            # Get the buffer for the embedded array
+            rt.embedded_array_buffer(tmp, tmp)
+
+            (req.num - 1).downto(0) do |i|
+              rt.push rt.buffer_ref(tmp, i), name: "array ref"
+            end
+
+          }.else {
+            # number of nils to push = tmp - req.num
+            rt.write tmp2, req.num
+            rt.sub tmp2, tmp
+
+            # Copy the stack top to a temp reg
+            rt.load_address_in stack, stack_top
+
+            rt.while(tmp2) {
+              rt.write_memory stack.to_register, 0, @fisk.imm(Qnil)
+              rt.add stack, Fiddle::SIZEOF_VOIDP
+              rt.dec(tmp2)
+            }
+
+            # Get the array reference back
+            rt.pop_reg tmp2
+
+            # Get the buffer for the embedded array
+            rt.embedded_array_buffer(tmp2, tmp2)
+
+            # Push to the end of the array
+            rt.push_reg stack
+            rt.write stack, tmp
+            rt.mult stack, Fiddle::SIZEOF_VOIDP, stack
+            rt.add tmp2, stack
+            rt.sub tmp2, Fiddle::SIZEOF_VOIDP
+            rt.pop_reg stack
+
+            rt.while(tmp) {
+              rt.push_reg tmp2
+              rt.load_from_reg tmp2.to_register, 0, tmp2.to_register
+              rt.write_to_mem stack.to_register, 0, tmp2.to_register
+              rt.pop_reg tmp2
+              rt.add stack, Fiddle::SIZEOF_VOIDP
+              rt.sub tmp2, Fiddle::SIZEOF_VOIDP
+              rt.dec(tmp)
+            }
+          }
+        }
+      }
+    end
+
     def compile_expandarray cfp, req, loc
       stack = RbControlFrameStruct.sp(cfp)
 
@@ -2680,92 +2741,52 @@ class TenderJIT
       entry_loc  = jit_buffer.address
 
       with_runtime(temp_stack) do |rt|
-        case rb.rb_type(seen_ptr)
-        when T_ARRAY
+        # Is this a tagged pointer?  See `handle_expandarray`
+        if seen_ptr & 1 == 1
+          rt.if_test_bit(stack_top, 1) {
+            rt.temp_var { |tmp|
+              tmp.write stack_top
+
+              # clear the tag bit
+              rt.and(tmp.to_register, ~1)
+              compile_embedded_expandarray(rt, req, tmp, stack_top)
+            }
+            # Remove the machine stack allocated "Ruby object"
+            rt.add @fisk.rsp, RUBY_OBJECT_ON_STACK_SIZE
+
+          }.else {
+            # recompile
+            rt.patchable_jump req.deferred_entry
+
+            # FIXME: It's weird that as we compile things we'll have to jump
+            # back here, then jump back to the origin.  It would be nice to
+            # directly jump back to the origin.  I need to figure out a way
+            # to do that.
+          }
+        else
+          raise "This should never happen" unless rb.rb_type(seen_ptr) == T_ARRAY
+
           # Compile time check
           if rb.embedded_array?(seen_ptr)
+            rt.temp_var { |tmp|
+              # Dereference the stack top to get the array
+              tmp.write stack_top
 
-            # Verify the compile time check
-            rt.if_embedded_array?(stack_top) {
-              rt.temp_var { |tmp|
+              # Verify the compile time check
+              rt.if_embedded_array?(tmp) {
+                compile_embedded_expandarray(rt, req, tmp, stack_top)
+              }.else {
+                # recompile
+                rt.patchable_jump req.deferred_entry
 
-                rt.embedded_array_length(stack_top, tmp)
-
-                rt.if(tmp, :>=, req.num) {
-                  # Get the buffer for the embedded array
-                  rt.embedded_array_buffer(stack_top, tmp)
-
-                  (req.num - 1).downto(0) do |i|
-                    rt.push rt.buffer_ref(tmp, i), name: "array ref"
-                  end
-
-                  # great!
-                  rt.jump jit_buffer.memory.to_i + return_loc
-                }.else {
-                  rt.temp_var { |tmp2|
-                    rt.temp_var { |stack|
-                      # number of nils to push = tmp - req.num
-                      rt.write tmp2, req.num
-                      rt.sub tmp2, tmp
-
-                      # Dereference the stack top to get the array
-                      rt.write stack, stack_top
-
-                      # Push the array reference on the stack so we can get it again later
-                      rt.push_reg stack
-
-                      # Copy the stack top to a temp reg
-                      rt.load_address_in stack, stack_top
-
-                      rt.while(tmp2) {
-                        rt.write_memory stack.to_register, 0, @fisk.imm(Qnil)
-                        rt.add stack, Fiddle::SIZEOF_VOIDP
-                        rt.dec(tmp2)
-                      }
-
-                      # Get the array reference back
-                      rt.pop_reg tmp2
-
-                      # Get the buffer for the embedded array
-                      rt.embedded_array_buffer(tmp2, tmp2)
-
-                      # Push to the end of the array
-                      rt.push_reg stack
-                      rt.write stack, tmp
-                      rt.mult stack, Fiddle::SIZEOF_VOIDP, stack
-                      rt.add tmp2, stack
-                      rt.sub tmp2, Fiddle::SIZEOF_VOIDP
-                      rt.pop_reg stack
-
-                      rt.while(tmp) {
-                        rt.push_reg tmp2
-                        rt.load_from_reg tmp2.to_register, 0, tmp2.to_register
-                        rt.write_to_mem stack.to_register, 0, tmp2.to_register
-                        rt.pop_reg tmp2
-                        rt.add stack, Fiddle::SIZEOF_VOIDP
-                        rt.sub tmp2, Fiddle::SIZEOF_VOIDP
-                        rt.dec(tmp)
-                      }
-                    }
-                  }
-
-                  # great!
-                  rt.jump jit_buffer.memory.to_i + return_loc
-                }
+                # FIXME: Same as above fixme
               }
-            }.else {
-              # recompile
-              rt.patchable_jump req.deferred_entry
-
-              # FIXME: It's weird that as we compile things we'll have to jump
-              # back here, then jump back to the origin.  It would be nice to
-              # directly jump back to the origin.  I need to figure out a way
-              # to do that.
-              rt.jump jit_buffer.memory.to_i + return_loc
             }
           else
-            rt.if_extended_array?(stack_top) {
-              rt.temp_var do |tmp|
+            rt.temp_var { |tmp|
+              tmp.write stack_top
+
+              rt.if_extended_array?(tmp) {
                 # Write the array length in to the `len` register
                 rt.extended_array_length(stack_top, tmp)
 
@@ -2776,9 +2797,6 @@ class TenderJIT
                   (req.num - 1).downto(0) do |i|
                     rt.push rt.buffer_ref(tmp, i), name: "array ref"
                   end
-
-                  # great!
-                  rt.jump jit_buffer.memory.to_i + return_loc
                 }.else {
                   rt.temp_var { |tmp2|
                     rt.temp_var { |stack|
@@ -2826,22 +2844,18 @@ class TenderJIT
                       }
                     }
                   }
-
-                  # great!
-                  rt.jump jit_buffer.memory.to_i + return_loc
-                  rt.break
                 }
-              end
-            }.else {
-              # recompile
-              rt.patchable_jump req.deferred_entry
-              # FIXME: see above
-              rt.jump jit_buffer.memory.to_i + return_loc
+              }.else {
+                # recompile
+                rt.patchable_jump req.deferred_entry
+                # FIXME: see above
+              }
             }
           end
-        else
-          raise NotImplementedError
         end
+
+        # great!
+        rt.jump jit_buffer.memory.to_i + return_loc
       end
 
       patch_source_jump jit_buffer, at: patch_loc, to: entry_loc
@@ -2849,10 +2863,74 @@ class TenderJIT
       entry_loc
     end
 
+    RUBY_OBJECT_ON_STACK_SIZE = 48
+
+    def compile_push_stack_array rt
+      loc = @temp_stack.pop
+
+      write_loc = @temp_stack.push :unknown
+      # Allocate a fake embedded array on the stack
+      rt.temp_var do |tmp|
+        rt.sub @fisk.rsp, RUBY_OBJECT_ON_STACK_SIZE
+        rt.write tmp, @fisk.rsp
+        rt.add tmp, Fiddle::SIZEOF_VOIDP
+
+        flags = Ruby::T_ARRAY |
+          (Ruby::RARRAY_EMBED_FLAG) |
+          (3 << Ruby::RARRAY_EMBED_LEN_SHIFT)
+
+        rt.write_to_mem(tmp, RBasic.offsetof("flags"), flags)
+        rt.write(rt.pointer(tmp, type: RArray).as.ary[0], loc)
+        rt.write(rt.pointer(tmp, type: RArray).as.ary[1], Qnil)
+        rt.write(rt.pointer(tmp, type: RArray).as.ary[2], Qnil)
+
+        # Make it look like an integer so that the GC won't try to mark
+        rt.inc tmp
+        rt.write write_loc, tmp
+      end
+    end
+
+    def handle_coercearray
+      addr = Fiddle::Handle::DEFAULT["rb_check_array_type"]
+
+      loc = @temp_stack.pop
+      write_loc = @temp_stack.push :unknown
+      with_runtime do |rt|
+        rt.if(rt.RB_SPECIAL_CONST_P(loc)) {
+          rt.if_nil?(rt.call_cfunc(addr, [loc])) {
+            compile_push_stack_array(rt)
+          }.else {
+            rt.write(write_loc, rt.return_value)
+          }
+        }.else {
+          rt.if_array?(loc) {
+            # do nothing
+          }.else {
+            rt.if_nil?(rt.call_cfunc(addr, [loc])) {
+              compile_push_stack_array(rt)
+            }.else {
+              rt.write(write_loc, rt.return_value)
+            }
+          }
+        }
+      end
+    end
+
     # num is the number of elements we need to expand
     # flag is special
     def handle_expandarray num, flag
       raise NotImplementedError if flag != 0
+
+      # handle_coercearray will try to coerce the stack's top value to an array
+      # see vm_expandarray.  If the top of the stack isn't an array, it will
+      # *allocate* an array on the machine's stack.  Then push that value on
+      # the stack and tag it as an int by setting the lower bit to 1.  This
+      # guarantees that the `compile_expandarray` runtime check will only ever
+      # see an "int" which is actually a tagged array, or a real array.  If
+      # it's tagged we just have to remove the tag and use it as an array.
+      # Also if it's tagged we need to unwind rsp.
+
+      handle_coercearray
 
       #sp_inc = num - 1 + (flag & 1 ? 1 : 0);
 
@@ -2872,15 +2950,11 @@ class TenderJIT
       req.deferred_entry = deferred.entry.to_i
 
       # attr rb_snum_t sp_inc = (rb_snum_t)num - 1 + (flag & 1 ? 1 : 0);
-      loc = @temp_stack.pop
+      @temp_stack.pop
       num.times { @temp_stack.push :unknown }
+
       with_runtime do |rt|
-        rt.if(rt.RB_SPECIAL_CONST_P(loc)) {
-          rt.break
-        }.else {
-          # Jump in to the deferred compiler
-          rt.patchable_jump req.deferred_entry
-        }
+        rt.patchable_jump req.deferred_entry
       end
     end
 

--- a/lib/tenderjit/ruby.rb
+++ b/lib/tenderjit/ruby.rb
@@ -92,6 +92,14 @@ class TenderJIT
       self.RB_IMMEDIATE_P(obj_addr) || !self.RB_TEST(obj_addr)
     end
 
+    def embedded_array? obj_addr
+      if rb_type(obj_addr) == Ruby::T_ARRAY
+        (RBasic.flags(obj_addr) & Ruby::RARRAY_EMBED_FLAG) == Ruby::RARRAY_EMBED_FLAG
+      else
+        false
+      end
+    end
+
     def rb_class_of obj_addr
       if !self.RB_SPECIAL_CONST_P(obj_addr)
         RBasic.klass(obj_addr).to_i

--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -407,7 +407,13 @@ class TenderJIT
             @fisk.cmp op1, op2
           end
         end
-        @fisk.jg else_label # else label
+
+        case op
+        when :>
+          @fisk.jg else_label # else label
+        else
+          raise NotImplementedError
+        end
       else
         if lhs.respond_to?(:call)
           lhs.call(@fisk)

--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -39,7 +39,7 @@ class TenderJIT
 
       loc = temp_stack.first.loc + (margin / Fiddle::SIZEOF_VOIDP)
       with_ref(loc) do |reg|
-        self.if(reg, :>, REG_CFP) {
+        self.if(reg, :<, REG_CFP) {
           # do nothing
         }.else {
           jump(exit_location)
@@ -409,8 +409,8 @@ class TenderJIT
         end
 
         case op
-        when :>
-          @fisk.jg else_label # else label
+        when :<
+          @fisk.jge else_label # else label
         else
           raise NotImplementedError
         end

--- a/test/instructions/expandarray_test.rb
+++ b/test/instructions/expandarray_test.rb
@@ -5,8 +5,8 @@ require "helper"
 class TenderJIT
   class ExpandarrayTest < JITTest
     def expandarray list
-      a, b = list
-      [a, b]
+      a, b, c = list
+      [a, b, c]
     end
 
     def test_expandarray_not_embedded_long_enough
@@ -39,7 +39,7 @@ class TenderJIT
 
       jit.enable!
       # Heat the JIT with an embedded array
-      expandarray([1, 2])
+      expandarray([1, 2, 3])
 
       # Call again with an extended array
       actual = expandarray([1, 2, 3, 4])
@@ -53,7 +53,7 @@ class TenderJIT
     end
 
     def test_expandarray_extended_to_embedded
-      expected = expandarray([1, 2])
+      expected = expandarray([1, 2, 3])
 
       jit.compile method(:expandarray)
       assert_equal 1, jit.compiled_methods
@@ -64,7 +64,7 @@ class TenderJIT
       expandarray([1, 2, 3, 4])
 
       # Call again with an embedded array
-      actual = expandarray([1, 2])
+      actual = expandarray([1, 2, 3])
 
       jit.disable!
       assert_equal expected, actual
@@ -75,26 +75,6 @@ class TenderJIT
     end
 
     def test_expandarray_heap_embedded_too_short
-      skip "FIXME"
-      expected = expandarray([1])
-
-      assert_has_insn method(:expandarray), insn: :expandarray
-
-      jit.compile method(:expandarray)
-      assert_equal 1, jit.compiled_methods
-      assert_equal 0, jit.executed_methods
-
-      jit.enable!
-      actual = expandarray([1])
-      jit.disable!
-      assert_equal expected, actual
-
-      assert_equal 1, jit.compiled_methods
-      assert_equal 1, jit.executed_methods
-      assert_equal 0, jit.exits
-    end
-
-    def test_expandarray_heap_embedded_long_enough
       expected = expandarray([1, 2])
 
       assert_has_insn method(:expandarray), insn: :expandarray
@@ -105,6 +85,49 @@ class TenderJIT
 
       jit.enable!
       actual = expandarray([1, 2])
+      jit.disable!
+      assert_equal expected, actual
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
+    def expandarray_big x
+      a, b, c, d, e = x
+      [a, b, c, d, e]
+    end
+
+    def test_expandarray_heap_extended_too_short
+      expected = expandarray_big([1, 2, 3, 4])
+
+      assert_has_insn method(:expandarray_big), insn: :expandarray
+
+      jit.compile method(:expandarray_big)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      actual = expandarray_big([1, 2, 3, 4])
+      jit.disable!
+      assert_equal expected, actual
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
+    def test_expandarray_heap_embedded_long_enough
+      expected = expandarray([1, 2, 3])
+
+      assert_has_insn method(:expandarray), insn: :expandarray
+
+      jit.compile method(:expandarray)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      actual = expandarray([1, 2, 3])
       jit.disable!
       assert_equal expected, actual
 

--- a/test/instructions/expandarray_test.rb
+++ b/test/instructions/expandarray_test.rb
@@ -28,6 +28,30 @@ class TenderJIT
       assert_equal 0, jit.exits
     end
 
+    def test_expandarray_embedded_to_extended
+      expected = expandarray([1, 2, 3, 4])
+
+      assert_has_insn method(:expandarray), insn: :expandarray
+
+      jit.compile method(:expandarray)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      # Heat the JIT with an embedded array
+      expandarray([1, 2])
+
+      # Call again with an extended array
+      actual = expandarray([1, 2, 3, 4])
+
+      jit.disable!
+      assert_equal expected, actual
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 2, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
     def test_expandarray_heap_embedded_too_short
       skip "FIXME"
       expected = expandarray([1])

--- a/test/instructions/expandarray_test.rb
+++ b/test/instructions/expandarray_test.rb
@@ -4,8 +4,48 @@ require "helper"
 
 class TenderJIT
   class ExpandarrayTest < JITTest
-    def test_expandarray
-      skip "Please implement expandarray!"
+    def expandarray list
+      a, b = list
+      [a, b]
+    end
+
+    def test_expandarray_heap_embedded_long_enough
+      expected = expandarray([1, 2])
+
+      assert_has_insn method(:expandarray), insn: :expandarray
+
+      jit.compile method(:expandarray)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      actual = expandarray([1, 2])
+      jit.disable!
+      assert_equal expected, actual
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
+    def test_expandarray_special
+      skip "FIXME"
+      expected = expandarray({a: 1, b: 2})
+
+      assert_has_insn method(:expandarray), insn: :expandarray
+
+      jit.compile method(:expandarray)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      actual = expandarray(true)
+      jit.disable!
+      assert_equal expected, actual
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
     end
   end
 end

--- a/test/instructions/expandarray_test.rb
+++ b/test/instructions/expandarray_test.rb
@@ -52,6 +52,28 @@ class TenderJIT
       assert_equal 0, jit.exits
     end
 
+    def test_expandarray_extended_to_embedded
+      expected = expandarray([1, 2])
+
+      jit.compile method(:expandarray)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      # Heat the JIT with an extended array
+      expandarray([1, 2, 3, 4])
+
+      # Call again with an embedded array
+      actual = expandarray([1, 2])
+
+      jit.disable!
+      assert_equal expected, actual
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 2, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
     def test_expandarray_heap_embedded_too_short
       skip "FIXME"
       expected = expandarray([1])

--- a/test/instructions/expandarray_test.rb
+++ b/test/instructions/expandarray_test.rb
@@ -136,9 +136,8 @@ class TenderJIT
       assert_equal 0, jit.exits
     end
 
-    def test_expandarray_special
-      skip "FIXME"
-      expected = expandarray({a: 1, b: 2})
+    def test_expandarray_special_const
+      expected = expandarray(true)
 
       assert_has_insn method(:expandarray), insn: :expandarray
 
@@ -148,6 +147,43 @@ class TenderJIT
 
       jit.enable!
       actual = expandarray(true)
+      jit.disable!
+      assert_equal expected, actual
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
+    def test_expandarray_special_const_then_array
+      expected = expandarray([1, 2, 3])
+
+      jit.compile method(:expandarray)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      # heat jit with special const
+      expandarray(true)
+      actual = expandarray([1, 2, 3])
+      jit.disable!
+      assert_equal expected, actual
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 2, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
+    def test_expandarray_hash
+      expected = expandarray({a: 1, b: 2})
+
+      jit.compile method(:expandarray)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      # heat jit with special const
+      actual = expandarray({a: 1, b: 2})
       jit.disable!
       assert_equal expected, actual
 

--- a/test/instructions/expandarray_test.rb
+++ b/test/instructions/expandarray_test.rb
@@ -9,6 +9,45 @@ class TenderJIT
       [a, b]
     end
 
+    def test_expandarray_not_embedded_long_enough
+      expected = expandarray([1, 2, 3, 4])
+
+      assert_has_insn method(:expandarray), insn: :expandarray
+
+      jit.compile method(:expandarray)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      actual = expandarray([1, 2, 3, 4])
+      jit.disable!
+      assert_equal expected, actual
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
+    def test_expandarray_heap_embedded_too_short
+      skip "FIXME"
+      expected = expandarray([1])
+
+      assert_has_insn method(:expandarray), insn: :expandarray
+
+      jit.compile method(:expandarray)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      actual = expandarray([1])
+      jit.disable!
+      assert_equal expected, actual
+
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
     def test_expandarray_heap_embedded_long_enough
       expected = expandarray([1, 2])
 


### PR DESCRIPTION
This PR implements all cases of the `expandarray` instruction.

It does something kind of weird so I'll explain it here.  I broke the `expandarray` instruction in to two "instructions".  The first is "coercearray" and then the actual "expandarray" instruction.  In the case of code like:

```
a, b, c = true
```

The "coercearray" instruction will allocate memory by expanding the machine stack, then it will write a "Ruby object" to the machine stack.  Then pushes a reference to that object on to the Ruby stack.  Obviously this isn't allocated from the GC, so if the GC sees it there will be a bug.  So I tagged the pointer as an "integer".  The `expandarray` instruction always follows the `coercearray` instruction so it will only ever see a tagged array or a real array on the Ruby stack.  In the case of the tagged array, we just remove the tag and treat it as a normal array, then fix up the stack to get our memory back.  In the case of a regular array, we just perform as a regular array.

The `coercearray` instruction will subtract 48 from the stack because we need to make sure that we're dealing with evenly divisible "pushes" on to the stack.