### PR TITLE
Fix CFP error with setinstancevariable

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -688,6 +688,8 @@ class TenderJIT
       # jump back to the re-written jmp
       deferred.call
 
+      @temp_stack.pop
+
       req.deferred_entry = deferred.entry.to_i
 
       with_runtime do |rt|


### PR DESCRIPTION
I found a CFP consistency error (the stack wasn't alinged) while running
optcarrot.  This was my mistake.  We should probably have tests that
ensure stack sizes and/or add optcarrot to the tests