### PR TITLE
Runtime: Add autoalign support to Ruby func calling

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -2597,7 +2597,7 @@ class TenderJIT
               ctx.with_runtime do |rt|
                 # We pushed before calling the patchable jump,
                 # so this function call should already be aligned
-                rt.rb_funcall_without_alignment self, :compile_getblockparamproxy, [REG_CFP, req, rt.return_value]
+                rt.rb_funcall self, :compile_getblockparamproxy, [REG_CFP, req, rt.return_value], auto_align: false
                 rt.NUM2INT(rt.return_value)
 
                 rt.jump rt.return_value

--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -766,7 +766,7 @@ class TenderJIT
       raise NotImplementedError, "too many parameters" if params.length > 6
       raise "No function location" unless func_loc > 0
 
-      align_cfunc_call(auto_align) do
+      align_funcall(auto_align) do
         params.each_with_index do |param, i|
           case param
           when Integer
@@ -795,7 +795,7 @@ class TenderJIT
     #
     # arguments:
     # - auto_align: true/false
-    def align_cfunc_call auto_align, &block
+    def align_funcall auto_align, &block
       if @cfunc_call_stack_depth % 8 != 0
         message = "Auto alignment is supported only for a stack depth multiple of 8 (current: #{@cfunc_call_stack_depth})"
         raise NotImplementedError, message


### PR DESCRIPTION
The principle is the same as call_cfunc(), which simplifies the code.

This PR is actually also useful to investigate the current issues with #101 (due to alignment issues).

Testing: If `auto_align` is disabled, the build fails.