### PR TITLE
Add a write barrier when writing the coverage array

### DIFF
--- a/lib/tenderjit.rb
+++ b/lib/tenderjit.rb
@@ -536,7 +536,9 @@ class TenderJIT
     ary = nil
     if ptr == 0 || ptr == Qnil
       ary = []
-      body.variable.coverage = Fiddle.dlwrap(ary)
+      ary_addr = Fiddle.dlwrap(ary)
+      body.variable.coverage = ary_addr
+      CFuncs.rb_gc_writebarrier(addr, ary_addr)
     else
       ary = Fiddle.dlunwrap(ptr)
     end

--- a/lib/tenderjit/c_funcs.rb
+++ b/lib/tenderjit/c_funcs.rb
@@ -46,5 +46,6 @@ class TenderJIT
     make_function "rb_iseq_label", [TYPE_VOIDP], TYPE_VOIDP
     make_function "rb_obj_class", [TYPE_VOIDP], TYPE_VOIDP
     make_function "rb_method_basic_definition_p", [TYPE_VOIDP, TYPE_INT], TYPE_INT
+    make_function "rb_gc_writebarrier", [TYPE_VOIDP, TYPE_VOIDP], TYPE_VOID
   end
 end


### PR DESCRIPTION
If we don't have a write barrier the coverage array could be collected
and then the iseq compiler will be collected too causing uncool errors