### PR TITLE
Pin and add patch request to list of requests

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -1702,6 +1702,7 @@ class TenderJIT
       read_loc = @temp_stack.pop
 
       patch_request = BranchUnless.new jump_pc, :jz, @temp_stack.dup.freeze
+      @compile_requests << Fiddle::Pinned.new(patch_request)
 
       deferred = @jit.deferred_call(@temp_stack) do |ctx|
         ctx.with_runtime do |rt|


### PR DESCRIPTION
We need to pin this patch request and add it to the list of requests.
The object is referenced from machine code so we need to make sure that
it stays alive and also that the GC doesn't move it