### PR TITLE
Implement handle_putspecialobject

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -2294,6 +2294,17 @@ class TenderJIT
       end
     end
 
+    def handle_putspecialobject type
+      special_type_addr = rb.rb_special_type type
+      return :stop unless special_type_addr
+
+      object_type = rb.rb_type special_type_addr
+
+      with_runtime do |rt|
+        rt.push special_type_addr, name: :special_type, type: object_type
+      end
+    end
+
     # `leave` instruction
     def handle_leave
       # FIXME: We need to check interrupts and exit

--- a/lib/tenderjit/ruby.rb
+++ b/lib/tenderjit/ruby.rb
@@ -23,7 +23,10 @@ class TenderJIT
     end
 
     # From vm_core.h
-
+    # Based on enum vm_special_object_type (vm_core.h)
+    VM_SPECIAL_OBJECT_TYPE = {
+      VM_SPECIAL_OBJECT_VMCORE => "rb_mRubyVMFrozenCore"
+    }.freeze
 
     INTEGER_REDEFINED_OP_FLAG = (1 << 0)
     FLOAT_REDEFINED_OP_FLAG   = (1 << 1)
@@ -271,6 +274,13 @@ class TenderJIT
       else
         RB_BUILTIN_TYPE(obj_addr)
       end
+    end
+
+    def rb_special_type type
+      special_symbol = VM_SPECIAL_OBJECT_TYPE[type]
+      return unless special_symbol
+
+      symbol_address(special_symbol)
     end
 
     def rb_current_vm

--- a/test/instructions/putspecialobject_test.rb
+++ b/test/instructions/putspecialobject_test.rb
@@ -4,8 +4,22 @@ require "helper"
 
 class TenderJIT
   class PutspecialobjectTest < JITTest
+    def putspecialobject
+      -> { 2 }.call
+    end
+
     def test_putspecialobject
-      skip "Please implement putspecialobject!"
+      jit.compile method(:putspecialobject)
+      assert_equal 1, jit.compiled_methods
+      assert_equal 0, jit.executed_methods
+
+      jit.enable!
+      v = putspecialobject
+      jit.disable!
+      assert_equal 2, v
+
+      assert_equal 2, jit.compiled_methods
+      assert_equal 2, jit.executed_methods
     end
   end
 end


### PR DESCRIPTION
The implementation for `putspecialobject` "based on" the YJIT implementation

Not sure if the implementation is actually working :sweat:
YJIT only generate code when the special type is "rb_mRubyVMFrozenCore", for the rest it returns `YJIT_CANT_COMPILE`.


If the implementation does not make sense, feel free to close the PR. I am actually learning a LOT hacking tenderjit. Thank you.
