### PR TITLE
Livestream 2021 12 17

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -585,10 +585,7 @@ class TenderJIT
     end
 
     def handle_dup
-      last = @temp_stack.peek(0)
-      with_runtime do |rt|
-        rt.push last.loc, name: last.name, type: last.type
-      end
+      handle_topn 0
     end
 
     def handle_concatstrings num

--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -2945,6 +2945,13 @@ class TenderJIT
       end
     end
 
+    def handle_topn n
+      with_runtime do |rt|
+        peek = @temp_stack.peek(n)
+        rt.push peek.loc, name: peek.name, type: peek.type
+      end
+    end
+
     # Call a C function at `func_loc` with `params`. Return value will be in RAX
     def call_cfunc func_loc, params, fisk = __
       raise NotImplementedError, "too many parameters" if params.length > 6

--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -786,9 +786,7 @@ class TenderJIT
 
       entry_location = jit_buffer.address
 
-      patch_loc = patch_loc - jit_buffer.memory.to_i
-
-      jit_buffer.patch_jump at: patch_loc, to: entry_location
+      loc = patch_loc - jit_buffer.memory.to_i
 
       param = req.temp_stack[0] # param
       recv  = req.temp_stack[1] # recv
@@ -814,7 +812,7 @@ class TenderJIT
               rt.call_cfunc rb.symbol_address("rb_hash_aref"), [recv, param], auto_align: false, preserve_tempvars: false
 
             else
-              raise NotImplementedError
+              compile_send cfp, req, patch_loc
             end
           }.else {
             rt.patchable_jump req.deferred_entry
@@ -822,8 +820,10 @@ class TenderJIT
         end
 
         # patched a jmp and it is 5 bytes
-        rt.jump jit_buffer.memory.to_i + patch_loc + 5
+        rt.jump jit_buffer.memory.to_i + loc + 5
       end
+
+      jit_buffer.patch_jump at: loc, to: entry_location
 
       entry_location
     end

--- a/test/instructions/opt_aref_test.rb
+++ b/test/instructions/opt_aref_test.rb
@@ -12,6 +12,24 @@ class TenderJIT
       assert_has_insn method(:aref), insn: :opt_aref
     end
 
+    def thing param; param; end
+
+    def test_aref_with_method
+      m = method(:thing)
+      expected = aref(m, "something")
+
+      jit.compile method(:aref)
+
+      jit.enable!
+      actual = aref(m, "something")
+      jit.disable!
+
+      assert_equal expected, actual
+      assert_equal 1, jit.compiled_methods
+      assert_equal 1, jit.executed_methods
+      assert_equal 0, jit.exits
+    end
+
     def test_opt_aref
       jit.compile method(:aref)
 

--- a/test/instructions/topn_test.rb
+++ b/test/instructions/topn_test.rb
@@ -44,7 +44,7 @@ class TenderJIT
       jit.disable!
 
       assert_equal 1, jit.compiled_methods
-      assert_equal 1, jit.exits
+      assert_equal 0, jit.exits
       assert_equal [:foo, :qux, :baz], v
     end
   end


### PR DESCRIPTION
topn and opt_aref improvements.  This brings us from 7 compiled methods in OptCarrot up to 21 compiled methods!!

Before:

```
$ be ruby ../optcarrot/bin/optcarrot --benchmark ../optcarrot/examples/Lan_Master.nes
fps: 39.95773360009497
checksum: 59662
{:EXITS=>181}
{:COMPILED_METHODS=>7}
{:EXECUTED=>104873}
[["getconstant", 4], ["topn", 177]]
```

After:

```
$ be ruby ../optcarrot/bin/optcarrot --benchmark ../optcarrot/examples/Lan_Master.nes 
fps: 38.721168861139155
checksum: 59662
{:EXITS=>94801}
{:COMPILED_METHODS=>21}
{:EXECUTED=>4205351}
[["getconstant", 6], ["opt_and", 12200], ["opt_or", 295], ["unknown_method_type", 82300]]
```