### PR TITLE
Refactor swap insn to properly swap item metadata

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -2420,15 +2420,9 @@ class TenderJIT
     end
 
     def handle_swap
-      with_runtime do |rt|
-        temp = rt.temp_var
-        temp.write @temp_stack[0]
-
-        rt.write @temp_stack[0], @temp_stack[1]
-        rt.write @temp_stack[1], temp
-
-        temp.release!
-      end
+      top_item, second_item = @temp_stack.pop_item, @temp_stack.pop_item
+      @temp_stack.push_item top_item
+      @temp_stack.push_item second_item
     end
 
     def handle_opt_aset call_data

--- a/lib/tenderjit/temp_stack.rb
+++ b/lib/tenderjit/temp_stack.rb
@@ -64,10 +64,21 @@ class TenderJIT
       m
     end
 
+    # Push a TempStack::Item on the temp stack. Returns the pushed item
+    def push_item item
+      @stack.push item
+      item
+    end
+
     # Pop a value from the temp stack. Returns the memory location where the
     # value should be read in machine code.
     def pop
       @stack.pop.loc
+    end
+
+    # Pop an item from the temp stack. Returns an instannce of TempStack::Item
+    def pop_item
+      @stack.pop
     end
 
     def initialize_copy other


### PR DESCRIPTION
Current implementation of `swap` instruction handler is not completely accurate
It seems to be correct but essentially we are loosing (confusing) metadata attached to `Item` objects that are being swapped 

This is a hacky test that I used to show the issue:
```ruby
    def test_swap_keeps_metadata
      m = method(:method_with_swap)
      rb_iseq = RubyVM::InstructionSequence.of(m)
      addr = RTypedData.data(Fiddle.dlwrap(rb_iseq))

      iseq_compiler = ISEQCompiler.new(jit, addr)
      stack = iseq_compiler.instance_variable_get(:@temp_stack)

      stack.push :second_item, type: :second_item_type
      stack.push :first_item, type: :first_item_type

      iseq_compiler.send :handle_swap

      # fails on main because the top item has wrong metadata
      assert_equal :second_item_type, stack.pop_item.type
    end

```

I also introduced `push_item` and `pop_item` method on the `TempStack`, it's not necessary but makes the handler fairly simple
I could have achieved the same by using something like:
```ruby
top_item = @temp_stack.peek(0)
second_item = @temp_stack.peek(1)
@temp_stack.pop # pop top item
@temp_stack.pop # pop second item

@temp_stack.push top_item.name, type: top_item.type
@temp_stack.push second_item.name, type: second_item.type
```

Please feel free to let me know if you think that adding these methods is kind of redundant as it exposes `Item` objects (`peak` also exposes `Item` objects but perhaps it is not preferable)

Thanks!
