### PR TITLE
Restrict temp vars instantiation to the block form

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -749,8 +749,6 @@ class TenderJIT
             temp.shl 8
             temp.or rt.pointer(rt.return_value)[0]
             rt.pointer(rt.return_value)[0] = temp
-            temp.release!
-
             rt.rb_funcall self, :compile_getinstancevariable, [REG_CFP, req, rt.return_value]
 
             rt.NUM2INT(rt.return_value)
@@ -760,6 +758,8 @@ class TenderJIT
             rt.break
             rt.jump exit_addr
           }
+
+          temp.release!
         end
       end
 
@@ -981,7 +981,6 @@ class TenderJIT
             temp.shl 8
             temp.or rt.pointer(rt.return_value)[0]
             rt.pointer(rt.return_value)[0] = temp
-            temp.release!
 
             rt.rb_funcall self, :compile_opt_send_without_block, [REG_CFP, compile_request, rt.return_value]
 
@@ -992,6 +991,8 @@ class TenderJIT
             rt.break
             rt.jump exit_addr
           }
+
+          temp.release!
         end
       end
 

--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -363,24 +363,24 @@ class TenderJIT
         #rt.check_vm_stack_overflow req.temp_stack, overflow_exit, local_size - param_size, iseq.body.stack_max
         cfp_ptr = rt.pointer(REG_CFP, type: RbControlFrameStruct)
 
-        temp = rt.temp_var
-        temp.write cfp_ptr.ep
-        ep_ptr = rt.pointer(temp)
+        rt.temp_var do |temp|
+          temp.write cfp_ptr.ep
+          ep_ptr = rt.pointer(temp)
 
-        # Find the LEP (or "Local" EP)
-        rt.test_flags(ep_ptr[VM_ENV_DATA_INDEX_FLAGS], VM_ENV_FLAG_LOCAL).else {
-          # TODO: need a test for this case
-          rt.break
-        }
+          # Find the LEP (or "Local" EP)
+          rt.test_flags(ep_ptr[VM_ENV_DATA_INDEX_FLAGS], VM_ENV_FLAG_LOCAL).else {
+            # TODO: need a test for this case
+            rt.break
+          }
 
-        # Get the block handler
-        temp.write ep_ptr[VM_ENV_DATA_INDEX_SPECVAL]
-        rt.if_eq(temp, VM_BLOCK_HANDLER_NONE) {
-          rt.jump side_exit
-        }.else {
-          rt.patchable_jump req.deferred_entry
-        }
-        temp.release!
+          # Get the block handler
+          temp.write ep_ptr[VM_ENV_DATA_INDEX_SPECVAL]
+          rt.if_eq(temp, VM_BLOCK_HANDLER_NONE) {
+            rt.jump side_exit
+          }.else {
+            rt.patchable_jump req.deferred_entry
+          }
+        end
       end
 
       method_entry_addr

--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -2417,13 +2417,12 @@ class TenderJIT
 
     def handle_swap
       with_runtime do |rt|
-        temp = rt.temp_var
-        temp.write @temp_stack[0]
+        rt.temp_var do |temp|
+          temp.write @temp_stack[0]
 
-        rt.write @temp_stack[0], @temp_stack[1]
-        rt.write @temp_stack[1], temp
-
-        temp.release!
+          rt.write @temp_stack[0], @temp_stack[1]
+          rt.write @temp_stack[1], temp
+        end
       end
     end
 

--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -1092,26 +1092,25 @@ class TenderJIT
         rt.push_reg REG_BP
 
         ret_loc = jit_buffer.memory.to_i + return_loc
-        var = rt.temp_var
-        var.write ret_loc
+        rt.temp_var do |var|
+          var.write ret_loc
 
-        # Callee will `ret` to return which will pop this address from the
-        # stack and jump to it
-        rt.push_reg var
+          # Callee will `ret` to return which will pop this address from the
+          # stack and jump to it
+          rt.push_reg var
 
-        # Dereference the JIT function address, skipping the REG_* assigments
-        # and jump to it
-        if $DEBUG
-          $stderr.puts "Should return to #{sprintf("%#x", ret_loc)}"
+          # Dereference the JIT function address, skipping the REG_* assigments
+          # and jump to it
+          if $DEBUG
+            $stderr.puts "Should return to #{sprintf("%#x", ret_loc)}"
+          end
+          var.write iseq.body.to_i
+          iseq_body = rt.pointer(var, type: RbIseqConstantBody)
+          var.write iseq_body.jit_func
+          rt.add var, @skip_bytes
+
+          rt.jump var
         end
-        var.write iseq.body.to_i
-        iseq_body = rt.pointer(var, type: RbIseqConstantBody)
-        var.write iseq_body.jit_func
-        rt.add var, @skip_bytes
-
-        rt.jump var
-
-        var.release!
       end
     end
 

--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -730,34 +730,33 @@ class TenderJIT
 
       deferred = @jit.deferred_call(@temp_stack) do |ctx|
         ctx.with_runtime do |rt|
-          temp = rt.temp_var
-          temp.write rt.pointer(rt.return_value)[0]
-          temp.shl   24
-          temp.shr   32
-          rt.add     temp, 5
-          rt.add     temp, rt.return_value
+          rt.temp_var do |temp|
+            temp.write rt.pointer(rt.return_value)[0]
+            temp.shl   24
+            temp.shr   32
+            rt.add     temp, 5
+            rt.add     temp, rt.return_value
 
-          rt.if_eq(temp.to_register, deferred.entry.to_i) {
-            temp.write 0xFFFFFF_00000000_FF
-            temp.and rt.pointer(rt.return_value)[0]
-            rt.pointer(rt.return_value)[0] = temp
-            temp.write exit_addr
-            temp.sub rt.return_value
-            rt.sub temp.to_register, 5
-            temp.shl 8
-            temp.or rt.pointer(rt.return_value)[0]
-            rt.pointer(rt.return_value)[0] = temp
-            rt.rb_funcall self, :compile_getinstancevariable, [REG_CFP, req, rt.return_value]
+            rt.if_eq(temp.to_register, deferred.entry.to_i) {
+              temp.write 0xFFFFFF_00000000_FF
+              temp.and rt.pointer(rt.return_value)[0]
+              rt.pointer(rt.return_value)[0] = temp
+              temp.write exit_addr
+              temp.sub rt.return_value
+              rt.sub temp.to_register, 5
+              temp.shl 8
+              temp.or rt.pointer(rt.return_value)[0]
+              rt.pointer(rt.return_value)[0] = temp
+              rt.rb_funcall self, :compile_getinstancevariable, [REG_CFP, req, rt.return_value]
 
-            rt.NUM2INT(rt.return_value)
+              rt.NUM2INT(rt.return_value)
 
-            rt.jump rt.return_value
-          }.else {
-            rt.break
-            rt.jump exit_addr
-          }
-
-          temp.release!
+              rt.jump rt.return_value
+            }.else {
+              rt.break
+              rt.jump exit_addr
+            }
+          end
         end
       end
 

--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -712,17 +712,14 @@ class TenderJIT
     end
 
     # Create a temporary variable
-    def temp_var name = "temp_var"
+    def temp_var name = "temp_var", &block
       tv = TemporaryVariable.new @fisk.register(name), Fiddle::TYPE_VOIDP, Fiddle::SIZEOF_VOIDP, 0, self
 
       @active_temp_vars << tv
 
-      if block_given?
-        yield tv
-        self.release_temp(tv)
-      else
-        tv
-      end
+      yield tv
+
+      self.release_temp(tv)
     end
 
     # Push a register on the machine stack


### PR DESCRIPTION
Implementation of [this discussion](https://github.com/tenderlove/tenderjit/pull/101#discussion_r764462013).

The change was relatively straightforward, with the exception `Frames::Virtual#push()` (change [here](f0d7187b68)), which now requires some juggling.

The PR is very granular make it easier to isolate potential bugs/conflicts.