### PR TITLE
Set RAX to RIP

### DIFF
--- a/lib/tenderjit/runtime.rb
+++ b/lib/tenderjit/runtime.rb
@@ -687,7 +687,7 @@ class TenderJIT
       reg = @fisk.rax
       @fisk.mov(reg, loc)
       @fisk.test(reg, reg)        # Is the parameter Qfalse?
-      @fisk.cmovz(reg, @fisk.rsi) # If so, set the register to $rsi (it's non-zero)
+      @fisk.cmovz(reg, @fisk.rip) # If so, set the register to $rip (it's non-zero)
       @fisk.jz(is_immediate)      # cmov didn't clear ZF, so we can jump if it's 0
       @fisk.test(reg, __.uimm(RUBY_IMMEDIATE_MASK))
       @fisk.jnz(is_immediate)


### PR DESCRIPTION
RSI is not always non-zero (I'm not sure why I wrote that in the
comments) and in fact can definitely be zero.  I saw it contain zero on
Linux which meant that `false` was sometimes treated as a heap object.

This commit uses RIP rather than RSI because the instruction pointer
should never be 0.