### PR TITLE
Fix various bugs related to #110

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -819,11 +819,11 @@ class TenderJIT
 
             # We know it's an array at compile time
             if klass == ::Array
-              rt.call_cfunc rb.symbol_address("rb_ary_aref1"), [recv, param], auto_align: false, preserve_tempvars: false
+              rt.call_cfunc symbol_addr("rb_ary_aref1"), [recv, param], auto_align: false, preserve_tempvars: false
 
               # We know it's a hash at compile time
             elsif klass == ::Hash
-              rt.call_cfunc rb.symbol_address("rb_hash_aref"), [recv, param], auto_align: false, preserve_tempvars: false
+              rt.call_cfunc symbol_addr("rb_hash_aref"), [recv, param], auto_align: false, preserve_tempvars: false
 
             else
               compile_send cfp, req, patch_loc
@@ -882,13 +882,13 @@ class TenderJIT
             rt.temp_var do |x|
               x.write param1
               rt.FIX2LONG(x)
-              rt.call_cfunc(rb.symbol_address("rb_ary_store"), [recv, x, param2])
+              rt.call_cfunc(symbol_addr("rb_ary_store"), [recv, x, param2])
             end
             rt.return_value = param2
 
             # We know it's a hash at compile time
           elsif klass == ::Hash
-            rt.call_cfunc(rb.symbol_address("rb_hash_aset"), [recv, param1, param2])
+            rt.call_cfunc(symbol_addr("rb_hash_aset"), [recv, param1, param2])
             rt.return_value = param2
 
           else
@@ -1253,7 +1253,7 @@ class TenderJIT
           if req.has_blockarg?
             temp_stack = temp_stack.dup
             if temp_stack.peek(0).symbol?
-              rt.call_cfunc Fiddle::Handle::DEFAULT["rb_sym_to_proc"], [temp_stack.pop]
+              rt.call_cfunc symbol_addr("rb_sym_to_proc"), [temp_stack.pop]
               loc = temp_stack.push :proc
               rt.write loc, rt.return_value
             else
@@ -2433,9 +2433,9 @@ class TenderJIT
 
     def vm_splat_array read_loc, store_loc, flag
       with_runtime do |rt|
-        rb_check_to_array = rb.symbol_address("rb_check_to_array")
-        rb_ary_new_from_args = rb.symbol_address("rb_ary_new_from_args")
-        rb_ary_dup = rb.symbol_address("rb_ary_dup")
+        rb_check_to_array = symbol_addr("rb_check_to_array")
+        rb_ary_new_from_args = symbol_addr("rb_ary_new_from_args")
+        rb_ary_dup = symbol_addr("rb_ary_dup")
 
         rt.call_cfunc rb_check_to_array, [read_loc]
 
@@ -2569,7 +2569,7 @@ class TenderJIT
 
               if rb.RB_STATIC_SYM_P(block_handler)
                 rt.if(rt.RB_STATIC_SYM_P(ep_ptr[VM_ENV_DATA_INDEX_SPECVAL])) {
-                  addr = rb.symbol_address("rb_sym_to_proc")
+                  addr = Fiddle::Handle::DEFAULT["rb_sym_to_proc"]
                   rt.call_cfunc(addr, [ep_ptr[VM_ENV_DATA_INDEX_SPECVAL]])
                   # Set the block handler in EP
                   ep_ptr[-req.idx] = rt.return_value
@@ -2583,7 +2583,7 @@ class TenderJIT
                   rt.push_reg ep
                   rt.patchable_jump req.deferred_entry
                 }.else {
-                  addr = rb.symbol_address("rb_sym_to_proc")
+                  addr = Fiddle::Handle::DEFAULT["rb_sym_to_proc"]
                   rt.call_cfunc(addr, [ep_ptr[VM_ENV_DATA_INDEX_SPECVAL]])
                   # Set the block handler in EP
                   ep_ptr[-req.idx] = rt.return_value

--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -127,6 +127,8 @@ class TenderJIT
             print_str("#{sprintf("%04d", @insn_idx)} running   #{name.ljust(LJUST)} #{sprintf("%#x", @iseq.to_i)} SP #{@temp_stack.size}\n")
           end
           @fisk = Fisk.new
+          # Uncomment for finding GC related bugs
+          #GC.start
           v = send("handle_#{name}", *params)
           if v == :quit
             make_exit(name, @current_pc, @temp_stack).write_to jit_buffer

--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -469,7 +469,7 @@ class TenderJIT
           comp_req = CompileISeqBlock.new(iseq_ptr, temp_stack.dup.freeze)
           @compile_requests << Fiddle::Pinned.new(comp_req)
 
-          deferred = @jit.deferred_call(temp_stack) do |ctx|
+          deferred = @jit.deferred_call(NoFlush.new) do |ctx|
             ctx.with_runtime do |rt|
               rt.rb_funcall self, :compile_iseq, [REG_CFP, comp_req, rt.return_value]
 
@@ -497,6 +497,10 @@ class TenderJIT
       end
 
       method_entry_addr
+    end
+
+    class NoFlush
+      def flush x; end
     end
 
     def compile_invokeblock cfp, req, loc

--- a/lib/tenderjit/temp_stack.rb
+++ b/lib/tenderjit/temp_stack.rb
@@ -100,6 +100,10 @@ class TenderJIT
       @stack.size
     end
 
+    def empty?
+      @stack.empty?
+    end
+
     protected
 
     attr_reader :stack

--- a/test/ruby_internals_test.rb
+++ b/test/ruby_internals_test.rb
@@ -153,6 +153,7 @@ class TenderJIT
     def test_offset
       assert_equal Fiddle::Handle::DEFAULT["ruby_current_vm_ptr"], Ruby::SYMBOLS["ruby_current_vm_ptr"]
       assert_equal Fiddle::Handle::DEFAULT["rb_iseq_eval_main"], Ruby::SYMBOLS["rb_iseq_eval_main"]
+      assert_equal Fiddle::Handle::DEFAULT["rb_cInteger"], Ruby::SYMBOLS["rb_cInteger"]
     end
 
     def test_redefined_flag_len


### PR DESCRIPTION
This fixes various bugs related to #110, and I think may fix #110 altogether.

I tried to split the bug fixes in to various commits in order to document each issue I encountered.  I'm also going to write down the issues here.

## SP as relates to GC

Anything that allocates memory whether that's allocating a Ruby object or just calling `ruby_xmalloc` etc can possibly cause the GC to execute.  The GC must scan the Ruby stack in order to find objects that need to stay alive.  If we don't have the SP up to date in the frames then the GC may not find objects that need to stay alive and will prematurely collect them.  I'm not sure how to "enforce" this rule other than we need to be careful when calling any C functions to check whether or not the function can possibly allocate and then flush the SP if it does.

## Machine Stack misalignment

I found a place when the stack was misaligned before calling in to a C function.  This was just because the auto alignment assumed that we're at alignment 8, but [we actually push a value before jumping in ](https://github.com/tenderlove/tenderjit/blob/0fab41134016d32266e0c396d919290f8c700dc3/lib/tenderjit/iseq_compiler.rb#L2646-L2647), so the original assumption was incorrect in this case.

In order to fix that, I just made the alignment configurable.

I think we might want to investigate optionally adding some assembly right before `call` instructions that verifies `$rsp` is aligned.

## Incorrect stack flushing

This was probably the strangest and hardest to track down.  `deferred_call` calls will try to flush the SP to the current frame because they always contain an `rb_funcall` and we need to make sure the SP is flushed for GC purposes.  In the case we're going to jump in to a block, and the block has an iseq, for example code like this:

```ruby
foo { puts "hi" }
```

TJ will add a stub that compiles the iseq for the block.  The logic is essentially:

1. [Push frame](https://github.com/tenderlove/tenderjit/blob/0fab41134016d32266e0c396d919290f8c700dc3/lib/tenderjit/iseq_compiler.rb#L449-L455)
2. [Possibly execute stub that compiles the block iseqs](https://github.com/tenderlove/tenderjit/blob/0fab41134016d32266e0c396d919290f8c700dc3/lib/tenderjit/iseq_compiler.rb#L486)
3. [Jump in to the ISeqs for that block](https://github.com/tenderlove/tenderjit/blob/0fab41134016d32266e0c396d919290f8c700dc3/lib/tenderjit/iseq_compiler.rb#L491-L496)

The problem is that `deferred_call` will try to flush the SP to the current frame *at runtime*.  But at runtime we've pushed a new frame, and at compile time `deferred_call` only knows about the temporary stack that exists **before** the new frame was pushed.  So we end up flushing the SP for the previous frame on to the newly created frame.  This causes the EP to get totally messed up.

To fix this, I made a fake temp stack that when you try to flush it it does nothing.  I'm not really pleased with this, but it works for now.

## Wrong Symbol Addresses on Debug Builds

I was working with a Ruby that's compiled with `-O0` and `Ruby::SYMBOLS` seems to return wrong addresses in that case.  I'm not sure what the deal is, but I think we should use `Fiddle::Handle::DEFAULT` as much as possible since we know it'll find the right thing.  I'll try to figure out why the addresses are wrong, but for now I did this.