### PR TITLE
Fix the swap instruction

### DIFF
--- a/lib/tenderjit/iseq_compiler.rb
+++ b/lib/tenderjit/iseq_compiler.rb
@@ -2463,9 +2463,21 @@ class TenderJIT
     end
 
     def handle_swap
-      top_item, second_item = @temp_stack.pop_item, @temp_stack.pop_item
-      @temp_stack.push_item top_item
-      @temp_stack.push_item second_item
+      top_item = @temp_stack.pop_item
+      second_item = @temp_stack.pop_item
+
+      with_runtime do |rt|
+        rt.temp_var do |tv|
+          # Keep the second item in a temporary location
+          tv.write second_item.loc
+
+          loc = @temp_stack.push(top_item.name, type: top_item.type)
+          rt.write loc, top_item.loc
+
+          loc = @temp_stack.push(second_item.name, type: second_item.type)
+          rt.write loc, tv
+        end
+      end
     end
 
     def handle_opt_aset call_data

--- a/lib/tenderjit/temp_stack.rb
+++ b/lib/tenderjit/temp_stack.rb
@@ -64,12 +64,6 @@ class TenderJIT
       m
     end
 
-    # Push a TempStack::Item on the temp stack. Returns the pushed item
-    def push_item item
-      @stack.push item
-      item
-    end
-
     # Pop a value from the temp stack. Returns the memory location where the
     # value should be read in machine code.
     def pop

--- a/test/instructions/swap_test.rb
+++ b/test/instructions/swap_test.rb
@@ -22,5 +22,41 @@ class TenderJIT
       assert_equal 0, jit.exits
       assert_equal "expression", v
     end
+
+    class Thing
+      attr_reader :m
+
+      def initialize
+        @m = :hi
+      end
+
+      def write= m
+        @m = m
+      end
+    end
+
+    def topswap thing
+      _, thing.write = :foo
+    end
+
+    def test_topswap
+      m = method(:topswap)
+
+      thing = Thing.new
+      expected = topswap(thing)
+
+      thing2 = Thing.new
+
+      jit.compile(m)
+      jit.enable!
+      actual = topswap(thing2)
+      jit.disable!
+
+      assert_equal 2, jit.compiled_methods
+      assert_equal 0, jit.exits
+      assert_equal expected, actual
+      assert_nil thing.m
+      assert_nil thing2.m
+    end
   end
 end


### PR DESCRIPTION
The swap instruction wasn't actually writing anything to the stack, so
this fixed it.  The other problem is that it would pop an item, then
push the item back on the stack in the reverse order.  This doesn't seem
like a problem (because that's what `swap` is supposed to do), but each
item in the temporary stack keeps track of where it needs to be read in
relation to the base pointer.

Since we just push the same item reference back on the stack, it means
that subsequent instructions that read from the stack would see the
wrong offset in relation to the base pointer.